### PR TITLE
Add export frontmatter support and anchor ADR

### DIFF
--- a/docs/adr/2026-03-16-adopt-adr-process.md
+++ b/docs/adr/2026-03-16-adopt-adr-process.md
@@ -1,0 +1,85 @@
+---
+decision-id: 5f9f814e-3eda-429a-81d1-222ac47ac6f0
+date: 2026-03-16
+slug: adopt-a-process-for-recording-architectural-decisions-in-the-decision-logger-project
+status: logged
+---
+
+# Decision: Adopt a process for recording architectural decisions in the decision logger project
+
+---
+
+**Meeting:** Architectural Decision Records - Usage and Process
+**Participants:** Peter, Claude
+**Created:** 3/16/2026, 5:51:59 PM
+**Updated:** 3/16/2026, 8:08:54 PM
+**Decision ID:** 5f9f814e-3eda-429a-81d1-222ac47ac6f0
+
+---
+
+## Context
+
+The decision-logger project is a system for capturing and documenting decisions from meetings. As the project approaches its first public release, the team needs a formal process for recording its own architectural decisions — both to practice what the tool preaches, and to give future contributors clear reasoning behind key choices. Without a structured process, important decisions made during early development will be lost.
+
+## Tension
+
+Two forces create this tension. First, the team builds a tool for capturing decisions yet has no process for capturing its own — a credibility gap that becomes visible at public release. Second, AI-assisted development makes it dangerously easy to make significant architectural choices mid-conversation, without the deliberation those choices deserve. Without ADRs, neither problem is addressed.
+
+## Decision Question
+
+Should the decision-logger project adopt a formal ADR process for recording architectural decisions?
+
+## Options
+
+1. **Adopt ADRs** — establish a formal process for recording architectural decisions at the time they are made. Requires stopping to write a structured record, even in fast-moving or AI-assisted development sessions. Adds friction but creates a durable trail.
+
+2. **Remain ad-hoc** — continue making decisions informally through conversation, commit messages, and READMEs. Lower friction in the moment but leaves no reliable record of reasoning, rejected alternatives, or the conditions under which a decision should be revisited.
+
+## Criteria
+
+1. **Traceability** — can future contributors understand why a decision was made?
+2. **Alignment with project purpose** — does the approach reflect what the tool itself advocates?
+3. **Sustainability** — will the process actually be followed, or will it be abandoned under pressure?
+4. **AI-safety** — does it provide a check against casual architectural decisions made in AI conversations?
+5. **AI context architecture** — does it produce structured, durable records that AI assistants can draw on as reliable context in future sessions?
+
+## Analysis
+
+Ad-hoc documentation fails on almost every criterion. It undermines the project's purpose — a decision-logging tool that does not log its own decisions is not credible. It provides no traceability, no consistent structure, and no reliable record for future contributors or AI assistants to draw on.
+
+The critical differentiator is semantic architecture. Ad-hoc records — spread across commit messages, READMEs, and conversation logs — cannot provide the consistent, structured context that AI assistants need to reason reliably across sessions. Only a formal ADR process produces records with predictable shape: context, tension, options, criteria, outcome. This structure is what makes decisions machine-readable as well as human-readable.
+
+The sacrifice is real: ADRs require stopping to write, even under pressure. But the cost of not writing them compounds — each undocumented decision makes the next AI-assisted session slightly less grounded and the codebase slightly harder to reason about.
+
+## Decision Statement
+
+The decision-logger project adopts a formal ADR process for recording architectural decisions.
+
+## Outcome
+
+ADRs are adopted over ad-hoc documentation. The primary rationale is semantic architecture: only a structured, consistently shaped record can serve both human contributors and AI assistants reliably across time.
+
+Implementation:
+- ADRs are stored in `docs/adr/` in the repository root
+- Files are named `YYYY-MM-DD-slug.md` (e.g. `2026-03-16-adopt-adr-process.md`), avoiding sequential numbers which create coordination problems across branches and approval workflows
+- Each ADR includes a stable `decision-id` in its frontmatter (the UUID from the decision-logger system) to allow unambiguous cross-referencing independent of filename or date
+- ADRs are structured using the Deliberation Decision template fields as their content shape
+- This record is the anchor ADR for the process itself
+
+## Conditions Of Enough
+
+Revisit if: the ADR process is consistently skipped under development pressure; the template proves too heavyweight for the decisions being made; or tooling (e.g. the decision-logger export) changes the format significantly. The process should be reviewed after the first 10 ADRs are written to assess whether the structure is working.
+
+## Outstanding Issues
+
+1. **ADR export template** — a markdown export format needs to be defined and built, mapping the Deliberation Decision fields to the ADR file structure (including frontmatter with decision-id, date, and slug).
+2. **Dedicated ADR decision type** — the current Deliberation Decision template may warrant a specialised ADR variant with fields tuned specifically for architectural decisions (e.g. supersedes, status, affected components).
+3. **ADR review and approval process** — how ADRs move from draft to accepted, and who has authority to approve, is not yet defined.
+4. **Speaker names not appearing in transcript** — display bug to be investigated separately.
+5. **Context file not persisting across container recreations** — the decision-logger context store should use a named Docker volume rather than the container filesystem.
+
+---
+
+*Exported from Decision Logger on 3/16/2026, 8:11:25 PM*
+*Template: Deliberation Decision*
+*Flagged Decision ID: a966fd42-3512-4bb7-8860-76e1afb96fb9*

--- a/docs/plans/export-frontmatter-plan.md
+++ b/docs/plans/export-frontmatter-plan.md
@@ -1,0 +1,131 @@
+# Plan: Export Template Frontmatter Support
+
+**Status**: ready to implement
+**Branch**: `feature/export-frontmatter`
+**Worktree**: `../decision-logger-export-frontmatter`
+**Priority**: first-release feature
+
+---
+
+## Context
+
+ADR files need YAML frontmatter for stable cross-referencing and tooling compatibility. The current markdown export produces clean section headings but no frontmatter block. The `ExportTemplate` model has no mechanism to declare a preamble.
+
+This feature adds a `preamble` field to `ExportTemplate` — a string template rendered before the `# Decision:` heading — and seeds an ADR-specific export template for the Deliberation Decision deliberation template.
+
+---
+
+## Goal
+
+When a decision context is exported using an export template that declares a `preamble`, the output begins with a rendered YAML frontmatter block containing stable identifiers and metadata.
+
+### Example output
+
+```markdown
+---
+decision-id: 5f9f814e-3eda-429a-81d1-222ac47ac6f0
+date: 2026-03-16
+slug: adopt-adr-process
+status: accepted
+---
+
+# Decision: The decision-logger project adopts a formal ADR process...
+```
+
+---
+
+## Acceptance criteria
+
+- `ExportTemplate` has an optional `preamble` string field.
+- The markdown export service renders the preamble before the `# Decision:` heading when `preamble` is present.
+- Preamble supports these substitution variables:
+  - `{{decision-id}}` — the decision context UUID (`context.id`)
+  - `{{flagged-decision-id}}` — the flagged decision UUID (`context.flaggedDecisionId`)
+  - `{{date}}` — the context creation date in `YYYY-MM-DD` format
+  - `{{slug}}` — a URL-safe slug derived from the decision title
+  - `{{status}}` — the context status (`drafting`, `logged`, etc.)
+  - `{{title}}` — the resolved decision title
+- A seeded ADR export template exists for the Deliberation Decision template, with preamble pre-configured.
+- All existing exports without a preamble are unaffected.
+- Tests cover: preamble rendering, variable substitution, missing-variable graceful handling, no-preamble path.
+
+---
+
+## Implementation steps (TDD)
+
+Follow the canonical schema change flow from `CLAUDE.md`:
+
+### Step 1 — Schema (`packages/schema`)
+
+Add `preamble` to `ExportTemplateSchema`:
+
+```typescript
+preamble: z.string().optional(),
+```
+
+Also add to `CreateExportTemplateSchema` (already derived via `.omit()`).
+
+### Step 2 — Database (`packages/db`)
+
+1. Run `pnpm db:generate` — review generated SQL, expect a nullable `preamble` column on `export_templates`.
+2. Run `pnpm db:migrate`.
+3. Add the ADR export template to `packages/db/src/seed-data/decision-templates.ts`:
+
+```typescript
+export const DELIBERATION_ADR_EXPORT_TEMPLATE: CreateExportTemplate = {
+  deliberationTemplateId: DELIBERATION_TEMPLATE_ID, // 1e0b11f8-...
+  namespace: "core",
+  name: "ADR Export",
+  description: "Exports a Deliberation Decision as an Architectural Decision Record markdown file with YAML frontmatter.",
+  isDefault: false,
+  preamble: `---\ndecision-id: {{decision-id}}\ndate: {{date}}\nslug: {{slug}}\nstatus: {{status}}\n---`,
+  fields: [ /* same field order as deliberation template */ ],
+};
+```
+
+4. Run `pnpm db:seed`.
+
+### Step 3 — Service (`packages/core`)
+
+In `MarkdownExportService.exportToMarkdown`:
+
+1. Write failing test: export with a template that has a preamble → output starts with rendered frontmatter block.
+2. Add `renderPreamble(preamble: string, vars: Record<string, string>): string` private method — simple `string.replace` for each `{{variable}}`.
+3. Add `buildSlug(title: string): string` private method — lowercase, strip non-alphanumeric, replace spaces with hyphens.
+4. Call `renderPreamble` before the `# Decision:` heading when `exportTemplate.preamble` is present.
+5. Run tests — should pass.
+
+### Step 4 — Validation
+
+```bash
+pnpm build
+pnpm type-check
+pnpm lint:workspace
+pnpm --filter @repo/db test
+pnpm --filter @repo/core test
+pnpm db:migrate
+```
+
+---
+
+## Key files
+
+| File | Change |
+|------|--------|
+| `packages/schema/src/index.ts` | Add `preamble` to `ExportTemplateSchema` |
+| `packages/db/src/schema.ts` | `preamble` column (auto via drizzle-zod, verify) |
+| `packages/db/drizzle/` | Generated migration |
+| `packages/db/src/seed-data/decision-templates.ts` | ADR export template definition |
+| `packages/db/scripts/seed.ts` | Register new export template in seed |
+| `packages/core/src/services/markdown-export-service.ts` | Render preamble, add slug/variable helpers |
+| `packages/core/src/__tests__/markdown-export-service.test.ts` | Tests for preamble rendering |
+
+---
+
+## Notes
+
+- The `ExportTemplate` DB table is in `packages/db/src/schema.ts`. Confirm drizzle-zod picks up `preamble` automatically; if not, add the column manually.
+- The deliberation template ID for seeding is `1e0b11f8-b8de-478b-82d8-d670fa0375fa` (Deliberation Decision).
+- Do not add a templating engine dependency — simple `{{variable}}` string replacement is sufficient for the MVP.
+- Future: `{{meeting}}`, `{{participants}}`, `{{template-name}}` could be added as variables without a schema change.
+- The `[MANUALLY EDITED]` prefix has already been removed from the export service on `feature/mcp-decision-integration` — this branch is cut from that commit, so the fix is already present.

--- a/packages/core/src/__tests__/markdown-export-service.test.ts
+++ b/packages/core/src/__tests__/markdown-export-service.test.ts
@@ -272,6 +272,133 @@ describe("MarkdownExportService", () => {
     expect(markdown).not.toContain("## decision_statement");
   });
 
+  it("renders preamble before the # Decision heading when template has a preamble", async () => {
+    mockContextRepo.findById.mockResolvedValue({
+      ...context,
+      id: "5f9f814e-3eda-429a-81d1-222ac47ac6f0",
+      flaggedDecisionId: "fd-abc",
+      status: "logged",
+      title: "Adopt ADR Process",
+      createdAt: "2026-03-16T10:00:00Z",
+    });
+    mockTemplateRepo.findById.mockResolvedValue(template);
+    mockMeetingRepo.findById.mockResolvedValue(meeting);
+    mockFieldAssignmentRepo.findByTemplateId.mockResolvedValue([
+      { fieldId: "field-1", order: 0, required: true },
+    ]);
+    mockFieldRepo.findById.mockResolvedValue(decisionField);
+    mockExportTemplateService.getDefaultExportTemplate.mockResolvedValue({
+      id: "exp-adr",
+      deliberationTemplateId: "tpl-123",
+      namespace: "core",
+      name: "ADR Export",
+      description: "ADR export with frontmatter",
+      preamble: "---\ndecision-id: {{decision-id}}\ndate: {{date}}\nslug: {{slug}}\nstatus: {{status}}\n---",
+      fields: [{ fieldId: "field-1", order: 0, title: "Decision Statement" }],
+      version: 1,
+      isDefault: false,
+      isCustom: false,
+      createdAt: "2026-03-16T10:00:00Z",
+    });
+
+    const markdown = await service.exportToMarkdown("ctx-123", {
+      includeMetadata: false,
+    });
+
+    expect(markdown).toMatch(/^---\n/);
+    expect(markdown).toContain("decision-id: 5f9f814e-3eda-429a-81d1-222ac47ac6f0");
+    expect(markdown).toContain("date: 2026-03-16");
+    expect(markdown).toContain("slug: adopt-adr-process");
+    expect(markdown).toContain("status: logged");
+    expect(markdown).toContain("---\n\n# Decision:");
+    // preamble must appear before the heading
+    expect(markdown.indexOf("---")).toBeLessThan(markdown.indexOf("# Decision:"));
+  });
+
+  it("substitutes {{title}} variable in preamble", async () => {
+    mockContextRepo.findById.mockResolvedValue({
+      ...context,
+      title: "Use PostgreSQL",
+    });
+    mockTemplateRepo.findById.mockResolvedValue(template);
+    mockMeetingRepo.findById.mockResolvedValue(meeting);
+    mockFieldAssignmentRepo.findByTemplateId.mockResolvedValue([
+      { fieldId: "field-1", order: 0, required: true },
+    ]);
+    mockFieldRepo.findById.mockResolvedValue(decisionField);
+    mockExportTemplateService.getDefaultExportTemplate.mockResolvedValue({
+      id: "exp-title",
+      deliberationTemplateId: "tpl-123",
+      namespace: "core",
+      name: "Title Export",
+      description: "Export with title var",
+      preamble: "title: {{title}}",
+      fields: [{ fieldId: "field-1", order: 0 }],
+      version: 1,
+      isDefault: false,
+      isCustom: false,
+      createdAt: "2026-03-16T10:00:00Z",
+    });
+
+    const markdown = await service.exportToMarkdown("ctx-123", { includeMetadata: false });
+
+    expect(markdown).toContain("title: Use PostgreSQL");
+  });
+
+  it("leaves unknown variables unreplaced when preamble contains missing vars", async () => {
+    mockContextRepo.findById.mockResolvedValue(context);
+    mockTemplateRepo.findById.mockResolvedValue(template);
+    mockMeetingRepo.findById.mockResolvedValue(meeting);
+    mockFieldAssignmentRepo.findByTemplateId.mockResolvedValue([
+      { fieldId: "field-1", order: 0, required: true },
+    ]);
+    mockFieldRepo.findById.mockResolvedValue(decisionField);
+    mockExportTemplateService.getDefaultExportTemplate.mockResolvedValue({
+      id: "exp-unknown",
+      deliberationTemplateId: "tpl-123",
+      namespace: "core",
+      name: "Unknown Var Export",
+      description: "Has unknown var",
+      preamble: "foo: {{unknown-var}}\nbar: {{date}}",
+      fields: [{ fieldId: "field-1", order: 0 }],
+      version: 1,
+      isDefault: false,
+      isCustom: false,
+      createdAt: "2026-03-16T10:00:00Z",
+    });
+
+    const markdown = await service.exportToMarkdown("ctx-123", { includeMetadata: false });
+
+    expect(markdown).toContain("foo: {{unknown-var}}");
+    expect(markdown).toContain("bar: 2026-03-15");
+  });
+
+  it("does not prepend preamble when template has no preamble field", async () => {
+    mockContextRepo.findById.mockResolvedValue(context);
+    mockTemplateRepo.findById.mockResolvedValue(template);
+    mockMeetingRepo.findById.mockResolvedValue(meeting);
+    mockFieldAssignmentRepo.findByTemplateId.mockResolvedValue([
+      { fieldId: "field-1", order: 0, required: true },
+    ]);
+    mockFieldRepo.findById.mockResolvedValue(decisionField);
+    mockExportTemplateService.getDefaultExportTemplate.mockResolvedValue({
+      id: "exp-default",
+      deliberationTemplateId: "tpl-123",
+      namespace: "core",
+      name: "Standard Decision Default Export",
+      description: "Derived default export template for Standard Decision",
+      fields: [{ fieldId: "field-1", order: 0, title: "Decision Statement" }],
+      version: 1,
+      isDefault: true,
+      isCustom: false,
+      createdAt: "2026-03-15T18:00:00Z",
+    });
+
+    const markdown = await service.exportToMarkdown("ctx-123", { includeMetadata: false });
+
+    expect(markdown).toMatch(/^# Decision:/);
+  });
+
   it("uses an explicitly selected export template when exportTemplateId is provided", async () => {
     mockContextRepo.findById.mockResolvedValue(context);
     mockTemplateRepo.findById.mockResolvedValue(template);

--- a/packages/core/src/services/markdown-export-service.ts
+++ b/packages/core/src/services/markdown-export-service.ts
@@ -115,6 +115,21 @@ export class MarkdownExportService {
     // Header with decision title (prefer explicit context title, then derived statement)
     const title =
       this.resolveDecisionTitle(context.title, draftData, sortedFields) || "Untitled Decision";
+
+    // Preamble (e.g. YAML frontmatter) rendered before the heading
+    if (exportTemplate.preamble) {
+      const date = context.createdAt.slice(0, 10);
+      const vars: Record<string, string> = {
+        "decision-id": context.id,
+        "flagged-decision-id": context.flaggedDecisionId ?? "",
+        date,
+        slug: this.buildSlug(title),
+        status: context.status,
+        title,
+      };
+      markdown += this.renderPreamble(exportTemplate.preamble, vars) + "\n\n";
+    }
+
     markdown += `# Decision: ${title}\n\n`;
 
     // Metadata section
@@ -206,6 +221,22 @@ export class MarkdownExportService {
 
     const trimmed = value.trim();
     return trimmed.length > 0 ? trimmed : null;
+  }
+
+  private renderPreamble(preamble: string, vars: Record<string, string>): string {
+    return Object.entries(vars).reduce(
+      (result, [key, value]) => result.replaceAll(`{{${key}}}`, value),
+      preamble,
+    );
+  }
+
+  private buildSlug(title: string): string {
+    return title
+      .toLowerCase()
+      .replace(/[^a-z0-9\s-]/g, "")
+      .trim()
+      .replace(/\s+/g, "-")
+      .replace(/-+/g, "-");
   }
 
   private formatFieldHeading(fieldName: string, exportTitle?: string): string {

--- a/packages/db/drizzle/0012_sweet_romulus.sql
+++ b/packages/db/drizzle/0012_sweet_romulus.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "export_templates" ADD COLUMN "preamble" text;

--- a/packages/db/drizzle/meta/0012_snapshot.json
+++ b/packages/db/drizzle/meta/0012_snapshot.json
@@ -1,0 +1,2201 @@
+{
+  "id": "6eeb15a3-821a-435a-8434-0657075d4d89",
+  "prevId": "98ee7958-3550-466e-8305-53b2aefec887",
+  "version": "5",
+  "dialect": "pg",
+  "tables": {
+    "chunk_relevance": {
+      "name": "chunk_relevance",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "chunk_id": {
+          "name": "chunk_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "decision_context_id": {
+          "name": "decision_context_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "field_id": {
+          "name": "field_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "relevance": {
+          "name": "relevance",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tagged_by": {
+          "name": "tagged_by",
+          "type": "tagged_by",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tagged_at": {
+          "name": "tagged_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_chunk_relevance_chunk": {
+          "name": "idx_chunk_relevance_chunk",
+          "columns": [
+            "chunk_id"
+          ],
+          "isUnique": false
+        },
+        "idx_chunk_relevance_context": {
+          "name": "idx_chunk_relevance_context",
+          "columns": [
+            "decision_context_id"
+          ],
+          "isUnique": false
+        },
+        "idx_chunk_relevance_field": {
+          "name": "idx_chunk_relevance_field",
+          "columns": [
+            "field_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "chunk_relevance_chunk_id_transcript_chunks_id_fk": {
+          "name": "chunk_relevance_chunk_id_transcript_chunks_id_fk",
+          "tableFrom": "chunk_relevance",
+          "tableTo": "transcript_chunks",
+          "columnsFrom": [
+            "chunk_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "decision_context_windows": {
+      "name": "decision_context_windows",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "decision_context_id": {
+          "name": "decision_context_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chunk_ids": {
+          "name": "chunk_ids",
+          "type": "uuid[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "selection_strategy": {
+          "name": "selection_strategy",
+          "type": "selection_strategy",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_tokens": {
+          "name": "total_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_chunks": {
+          "name": "total_chunks",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "relevance_scores": {
+          "name": "relevance_scores",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "used_for": {
+          "name": "used_for",
+          "type": "used_for",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_context_windows_context": {
+          "name": "idx_context_windows_context",
+          "columns": [
+            "decision_context_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "decision_contexts": {
+      "name": "decision_contexts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "meeting_id": {
+          "name": "meeting_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "flagged_decision_id": {
+          "name": "flagged_decision_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active_field": {
+          "name": "active_field",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "locked_fields": {
+          "name": "locked_fields",
+          "type": "uuid[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::uuid[]"
+        },
+        "draft_data": {
+          "name": "draft_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "draft_versions": {
+          "name": "draft_versions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "suggested_tags": {
+          "name": "suggested_tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "decision_context_status",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'drafting'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_decision_contexts_meeting": {
+          "name": "idx_decision_contexts_meeting",
+          "columns": [
+            "meeting_id"
+          ],
+          "isUnique": false
+        },
+        "idx_decision_contexts_flagged": {
+          "name": "idx_decision_contexts_flagged",
+          "columns": [
+            "flagged_decision_id"
+          ],
+          "isUnique": false
+        },
+        "idx_decision_contexts_status": {
+          "name": "idx_decision_contexts_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "decision_contexts_meeting_id_meetings_id_fk": {
+          "name": "decision_contexts_meeting_id_meetings_id_fk",
+          "tableFrom": "decision_contexts",
+          "tableTo": "meetings",
+          "columnsFrom": [
+            "meeting_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "decision_contexts_flagged_decision_id_flagged_decisions_id_fk": {
+          "name": "decision_contexts_flagged_decision_id_flagged_decisions_id_fk",
+          "tableFrom": "decision_contexts",
+          "tableTo": "flagged_decisions",
+          "columnsFrom": [
+            "flagged_decision_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "decision_contexts_template_id_decision_templates_id_fk": {
+          "name": "decision_contexts_template_id_decision_templates_id_fk",
+          "tableFrom": "decision_contexts",
+          "tableTo": "decision_templates",
+          "columnsFrom": [
+            "template_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "decision_contexts_active_field_decision_fields_id_fk": {
+          "name": "decision_contexts_active_field_decision_fields_id_fk",
+          "tableFrom": "decision_contexts",
+          "tableTo": "decision_fields",
+          "columnsFrom": [
+            "active_field"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "decision_feedback": {
+      "name": "decision_feedback",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "decision_context_id": {
+          "name": "decision_context_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "field_id": {
+          "name": "field_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "draft_version_number": {
+          "name": "draft_version_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "field_version_id": {
+          "name": "field_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "feedback_rating",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "feedback_source",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text_reference": {
+          "name": "text_reference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_url": {
+          "name": "reference_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exclude_from_regeneration": {
+          "name": "exclude_from_regeneration",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_decision_feedback_context": {
+          "name": "idx_decision_feedback_context",
+          "columns": [
+            "decision_context_id"
+          ],
+          "isUnique": false
+        },
+        "idx_decision_feedback_field": {
+          "name": "idx_decision_feedback_field",
+          "columns": [
+            "field_id"
+          ],
+          "isUnique": false
+        },
+        "idx_decision_feedback_context_field": {
+          "name": "idx_decision_feedback_context_field",
+          "columns": [
+            "decision_context_id",
+            "field_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "decision_feedback_decision_context_id_decision_contexts_id_fk": {
+          "name": "decision_feedback_decision_context_id_decision_contexts_id_fk",
+          "tableFrom": "decision_feedback",
+          "tableTo": "decision_contexts",
+          "columnsFrom": [
+            "decision_context_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "decision_feedback_field_id_decision_fields_id_fk": {
+          "name": "decision_feedback_field_id_decision_fields_id_fk",
+          "tableFrom": "decision_feedback",
+          "tableTo": "decision_fields",
+          "columnsFrom": [
+            "field_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "decision_fields": {
+      "name": "decision_fields",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "namespace": {
+          "name": "namespace",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'core'"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "field_category",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "extraction_prompt": {
+          "name": "extraction_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "field_type": {
+          "name": "field_type",
+          "type": "field_type",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "placeholder": {
+          "name": "placeholder",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "validation_rules": {
+          "name": "validation_rules",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "is_custom": {
+          "name": "is_custom",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_decision_fields_namespace": {
+          "name": "idx_decision_fields_namespace",
+          "columns": [
+            "namespace"
+          ],
+          "isUnique": false
+        },
+        "idx_decision_fields_category": {
+          "name": "idx_decision_fields_category",
+          "columns": [
+            "category"
+          ],
+          "isUnique": false
+        },
+        "idx_decision_fields_name": {
+          "name": "idx_decision_fields_name",
+          "columns": [
+            "name"
+          ],
+          "isUnique": false
+        },
+        "uq_decision_fields_namespace_name_version": {
+          "name": "uq_decision_fields_namespace_name_version",
+          "columns": [
+            "namespace",
+            "name",
+            "version"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "decision_logs": {
+      "name": "decision_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "meeting_id": {
+          "name": "meeting_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "decision_context_id": {
+          "name": "decision_context_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "template_version": {
+          "name": "template_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fields": {
+          "name": "fields",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "decision_method": {
+          "name": "decision_method",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_chunk_ids": {
+          "name": "source_chunk_ids",
+          "type": "uuid[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logged_at": {
+          "name": "logged_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "logged_by": {
+          "name": "logged_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_decision_logs_meeting": {
+          "name": "idx_decision_logs_meeting",
+          "columns": [
+            "meeting_id"
+          ],
+          "isUnique": false
+        },
+        "idx_decision_logs_context": {
+          "name": "idx_decision_logs_context",
+          "columns": [
+            "decision_context_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "decision_logs_meeting_id_meetings_id_fk": {
+          "name": "decision_logs_meeting_id_meetings_id_fk",
+          "tableFrom": "decision_logs",
+          "tableTo": "meetings",
+          "columnsFrom": [
+            "meeting_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "decision_logs_decision_context_id_decision_contexts_id_fk": {
+          "name": "decision_logs_decision_context_id_decision_contexts_id_fk",
+          "tableFrom": "decision_logs",
+          "tableTo": "decision_contexts",
+          "columnsFrom": [
+            "decision_context_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "decision_logs_template_id_decision_templates_id_fk": {
+          "name": "decision_logs_template_id_decision_templates_id_fk",
+          "tableFrom": "decision_logs",
+          "tableTo": "decision_templates",
+          "columnsFrom": [
+            "template_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "decision_templates": {
+      "name": "decision_templates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "namespace": {
+          "name": "namespace",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'core'"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt_template": {
+          "name": "prompt_template",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "template_category",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_custom": {
+          "name": "is_custom",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_decision_templates_namespace": {
+          "name": "idx_decision_templates_namespace",
+          "columns": [
+            "namespace"
+          ],
+          "isUnique": false
+        },
+        "idx_decision_templates_category": {
+          "name": "idx_decision_templates_category",
+          "columns": [
+            "category"
+          ],
+          "isUnique": false
+        },
+        "uq_decision_templates_namespace_name_version": {
+          "name": "uq_decision_templates_namespace_name_version",
+          "columns": [
+            "namespace",
+            "name",
+            "version"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "expert_advice": {
+      "name": "expert_advice",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "decision_context_id": {
+          "name": "decision_context_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expert_id": {
+          "name": "expert_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expert_name": {
+          "name": "expert_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request": {
+          "name": "request",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "response": {
+          "name": "response",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mcp_tools_used": {
+          "name": "mcp_tools_used",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_at": {
+          "name": "requested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_expert_advice_context": {
+          "name": "idx_expert_advice_context",
+          "columns": [
+            "decision_context_id"
+          ],
+          "isUnique": false
+        },
+        "idx_expert_advice_expert": {
+          "name": "idx_expert_advice_expert",
+          "columns": [
+            "expert_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "expert_advice_decision_context_id_decision_contexts_id_fk": {
+          "name": "expert_advice_decision_context_id_decision_contexts_id_fk",
+          "tableFrom": "expert_advice",
+          "tableTo": "decision_contexts",
+          "columnsFrom": [
+            "decision_context_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "expert_advice_expert_id_expert_templates_id_fk": {
+          "name": "expert_advice_expert_id_expert_templates_id_fk",
+          "tableFrom": "expert_advice",
+          "tableTo": "expert_templates",
+          "columnsFrom": [
+            "expert_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "expert_templates": {
+      "name": "expert_templates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "expert_type",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt_template": {
+          "name": "prompt_template",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mcp_access": {
+          "name": "mcp_access",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "output_schema": {
+          "name": "output_schema",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_expert_templates_type": {
+          "name": "idx_expert_templates_type",
+          "columns": [
+            "type"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "export_template_field_assignments": {
+      "name": "export_template_field_assignments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "export_template_id": {
+          "name": "export_template_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "field_id": {
+          "name": "field_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_export_template_assignments_template": {
+          "name": "idx_export_template_assignments_template",
+          "columns": [
+            "export_template_id"
+          ],
+          "isUnique": false
+        },
+        "idx_export_template_assignments_field": {
+          "name": "idx_export_template_assignments_field",
+          "columns": [
+            "field_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "export_template_field_assignments_export_template_id_export_templates_id_fk": {
+          "name": "export_template_field_assignments_export_template_id_export_templates_id_fk",
+          "tableFrom": "export_template_field_assignments",
+          "tableTo": "export_templates",
+          "columnsFrom": [
+            "export_template_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "export_template_field_assignments_field_id_decision_fields_id_fk": {
+          "name": "export_template_field_assignments_field_id_decision_fields_id_fk",
+          "tableFrom": "export_template_field_assignments",
+          "tableTo": "decision_fields",
+          "columnsFrom": [
+            "field_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "export_templates": {
+      "name": "export_templates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "deliberation_template_id": {
+          "name": "deliberation_template_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "namespace": {
+          "name": "namespace",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'core'"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "preamble": {
+          "name": "preamble",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_custom": {
+          "name": "is_custom",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "lineage": {
+          "name": "lineage",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provenance": {
+          "name": "provenance",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_export_templates_deliberation_template": {
+          "name": "idx_export_templates_deliberation_template",
+          "columns": [
+            "deliberation_template_id"
+          ],
+          "isUnique": false
+        },
+        "idx_export_templates_namespace": {
+          "name": "idx_export_templates_namespace",
+          "columns": [
+            "namespace"
+          ],
+          "isUnique": false
+        },
+        "idx_export_templates_is_default": {
+          "name": "idx_export_templates_is_default",
+          "columns": [
+            "is_default"
+          ],
+          "isUnique": false
+        },
+        "uq_export_templates_namespace_name_version": {
+          "name": "uq_export_templates_namespace_name_version",
+          "columns": [
+            "namespace",
+            "name",
+            "version"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "export_templates_deliberation_template_id_decision_templates_id_fk": {
+          "name": "export_templates_deliberation_template_id_decision_templates_id_fk",
+          "tableFrom": "export_templates",
+          "tableTo": "decision_templates",
+          "columnsFrom": [
+            "deliberation_template_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "flagged_decisions": {
+      "name": "flagged_decisions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "meeting_id": {
+          "name": "meeting_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "suggested_title": {
+          "name": "suggested_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "context_summary": {
+          "name": "context_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chunk_ids": {
+          "name": "chunk_ids",
+          "type": "uuid[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "suggested_template_id": {
+          "name": "suggested_template_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "template_confidence": {
+          "name": "template_confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "flagged_decision_status",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_flagged_decisions_meeting": {
+          "name": "idx_flagged_decisions_meeting",
+          "columns": [
+            "meeting_id"
+          ],
+          "isUnique": false
+        },
+        "idx_flagged_decisions_status": {
+          "name": "idx_flagged_decisions_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "idx_flagged_decisions_priority": {
+          "name": "idx_flagged_decisions_priority",
+          "columns": [
+            "priority"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "flagged_decisions_meeting_id_meetings_id_fk": {
+          "name": "flagged_decisions_meeting_id_meetings_id_fk",
+          "tableFrom": "flagged_decisions",
+          "tableTo": "meetings",
+          "columnsFrom": [
+            "meeting_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "flagged_decisions_suggested_template_id_decision_templates_id_fk": {
+          "name": "flagged_decisions_suggested_template_id_decision_templates_id_fk",
+          "tableFrom": "flagged_decisions",
+          "tableTo": "decision_templates",
+          "columnsFrom": [
+            "suggested_template_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "llm_interactions": {
+      "name": "llm_interactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "decision_context_id": {
+          "name": "decision_context_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "field_id": {
+          "name": "field_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "operation": {
+          "name": "operation",
+          "type": "llm_interaction_operation",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt_segments": {
+          "name": "prompt_segments",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt_text": {
+          "name": "prompt_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "response_text": {
+          "name": "response_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parsed_result": {
+          "name": "parsed_result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "latency_ms": {
+          "name": "latency_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_count": {
+          "name": "token_count",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "llm_interactions_decision_context_idx": {
+          "name": "llm_interactions_decision_context_idx",
+          "columns": [
+            "decision_context_id"
+          ],
+          "isUnique": false
+        },
+        "llm_interactions_field_idx": {
+          "name": "llm_interactions_field_idx",
+          "columns": [
+            "field_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "mcp_servers": {
+      "name": "mcp_servers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "mcp_server_type",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_config": {
+          "name": "connection_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "mcp_server_status",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_mcp_servers_name": {
+          "name": "idx_mcp_servers_name",
+          "columns": [
+            "name"
+          ],
+          "isUnique": false
+        },
+        "idx_mcp_servers_status": {
+          "name": "idx_mcp_servers_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mcp_servers_name_unique": {
+          "name": "mcp_servers_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      }
+    },
+    "meetings": {
+      "name": "meetings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "participants": {
+          "name": "participants",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "meeting_status",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'proposed'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_meetings_status": {
+          "name": "idx_meetings_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "idx_meetings_date": {
+          "name": "idx_meetings_date",
+          "columns": [
+            "date"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "raw_transcripts": {
+      "name": "raw_transcripts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "meeting_id": {
+          "name": "meeting_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "transcript_source",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "format": {
+          "name": "format",
+          "type": "transcript_format",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uploaded_at": {
+          "name": "uploaded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "uploaded_by": {
+          "name": "uploaded_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_raw_transcripts_meeting": {
+          "name": "idx_raw_transcripts_meeting",
+          "columns": [
+            "meeting_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "raw_transcripts_meeting_id_meetings_id_fk": {
+          "name": "raw_transcripts_meeting_id_meetings_id_fk",
+          "tableFrom": "raw_transcripts",
+          "tableTo": "meetings",
+          "columnsFrom": [
+            "meeting_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "supplementary_content": {
+      "name": "supplementary_content",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "meeting_id": {
+          "name": "meeting_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "contexts": {
+          "name": "contexts",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_supcontent_meeting": {
+          "name": "idx_supcontent_meeting",
+          "columns": [
+            "meeting_id"
+          ],
+          "isUnique": false
+        },
+        "idx_supcontent_contexts": {
+          "name": "idx_supcontent_contexts",
+          "columns": [
+            "contexts"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "supplementary_content_meeting_id_meetings_id_fk": {
+          "name": "supplementary_content_meeting_id_meetings_id_fk",
+          "tableFrom": "supplementary_content",
+          "tableTo": "meetings",
+          "columnsFrom": [
+            "meeting_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "template_field_assignments": {
+      "name": "template_field_assignments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "field_id": {
+          "name": "field_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "required": {
+          "name": "required",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {
+        "idx_template_assignments_template": {
+          "name": "idx_template_assignments_template",
+          "columns": [
+            "template_id"
+          ],
+          "isUnique": false
+        },
+        "idx_template_assignments_field": {
+          "name": "idx_template_assignments_field",
+          "columns": [
+            "field_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "template_field_assignments_template_id_decision_templates_id_fk": {
+          "name": "template_field_assignments_template_id_decision_templates_id_fk",
+          "tableFrom": "template_field_assignments",
+          "tableTo": "decision_templates",
+          "columnsFrom": [
+            "template_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "template_field_assignments_field_id_decision_fields_id_fk": {
+          "name": "template_field_assignments_field_id_decision_fields_id_fk",
+          "tableFrom": "template_field_assignments",
+          "tableTo": "decision_fields",
+          "columnsFrom": [
+            "field_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "transcript_chunks": {
+      "name": "transcript_chunks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "meeting_id": {
+          "name": "meeting_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw_transcript_id": {
+          "name": "raw_transcript_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sequence_number": {
+          "name": "sequence_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "speaker": {
+          "name": "speaker",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chunk_strategy": {
+          "name": "chunk_strategy",
+          "type": "chunk_strategy",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_count": {
+          "name": "token_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "word_count": {
+          "name": "word_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contexts": {
+          "name": "contexts",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "topics": {
+          "name": "topics",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_transcript_chunks_meeting": {
+          "name": "idx_transcript_chunks_meeting",
+          "columns": [
+            "meeting_id"
+          ],
+          "isUnique": false
+        },
+        "idx_transcript_chunks_raw": {
+          "name": "idx_transcript_chunks_raw",
+          "columns": [
+            "raw_transcript_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "transcript_chunks_meeting_id_meetings_id_fk": {
+          "name": "transcript_chunks_meeting_id_meetings_id_fk",
+          "tableFrom": "transcript_chunks",
+          "tableTo": "meetings",
+          "columnsFrom": [
+            "meeting_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "transcript_chunks_raw_transcript_id_raw_transcripts_id_fk": {
+          "name": "transcript_chunks_raw_transcript_id_raw_transcripts_id_fk",
+          "tableFrom": "transcript_chunks",
+          "tableTo": "raw_transcripts",
+          "columnsFrom": [
+            "raw_transcript_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    }
+  },
+  "enums": {
+    "chunk_strategy": {
+      "name": "chunk_strategy",
+      "values": {
+        "fixed": "fixed",
+        "semantic": "semantic",
+        "speaker": "speaker",
+        "streaming": "streaming"
+      }
+    },
+    "decision_context_status": {
+      "name": "decision_context_status",
+      "values": {
+        "drafting": "drafting",
+        "reviewing": "reviewing",
+        "locked": "locked",
+        "logged": "logged"
+      }
+    },
+    "decision_method": {
+      "name": "decision_method",
+      "values": {
+        "consensus": "consensus",
+        "vote": "vote",
+        "authority": "authority",
+        "defer": "defer",
+        "reject": "reject"
+      }
+    },
+    "expert_type": {
+      "name": "expert_type",
+      "values": {
+        "technical": "technical",
+        "legal": "legal",
+        "stakeholder": "stakeholder",
+        "custom": "custom"
+      }
+    },
+    "feedback_rating": {
+      "name": "feedback_rating",
+      "values": {
+        "approved": "approved",
+        "needs_work": "needs_work",
+        "rejected": "rejected"
+      }
+    },
+    "feedback_source": {
+      "name": "feedback_source",
+      "values": {
+        "user": "user",
+        "expert_agent": "expert_agent",
+        "peer_user": "peer_user"
+      }
+    },
+    "field_category": {
+      "name": "field_category",
+      "values": {
+        "context": "context",
+        "evaluation": "evaluation",
+        "outcome": "outcome",
+        "metadata": "metadata"
+      }
+    },
+    "field_type": {
+      "name": "field_type",
+      "values": {
+        "text": "text",
+        "textarea": "textarea",
+        "select": "select",
+        "multiselect": "multiselect",
+        "number": "number",
+        "date": "date",
+        "url": "url"
+      }
+    },
+    "flagged_decision_status": {
+      "name": "flagged_decision_status",
+      "values": {
+        "pending": "pending",
+        "accepted": "accepted",
+        "rejected": "rejected",
+        "dismissed": "dismissed"
+      }
+    },
+    "llm_interaction_operation": {
+      "name": "llm_interaction_operation",
+      "values": {
+        "generate_draft": "generate_draft",
+        "regenerate_field": "regenerate_field"
+      }
+    },
+    "mcp_server_status": {
+      "name": "mcp_server_status",
+      "values": {
+        "active": "active",
+        "inactive": "inactive",
+        "error": "error"
+      }
+    },
+    "mcp_server_type": {
+      "name": "mcp_server_type",
+      "values": {
+        "stdio": "stdio",
+        "http": "http",
+        "sse": "sse"
+      }
+    },
+    "meeting_status": {
+      "name": "meeting_status",
+      "values": {
+        "proposed": "proposed",
+        "in_session": "in_session",
+        "ended": "ended"
+      }
+    },
+    "selection_strategy": {
+      "name": "selection_strategy",
+      "values": {
+        "all": "all",
+        "relevant": "relevant",
+        "recent": "recent",
+        "weighted": "weighted"
+      }
+    },
+    "tagged_by": {
+      "name": "tagged_by",
+      "values": {
+        "llm": "llm",
+        "rule": "rule",
+        "manual": "manual"
+      }
+    },
+    "template_category": {
+      "name": "template_category",
+      "values": {
+        "standard": "standard",
+        "technology": "technology",
+        "strategy": "strategy",
+        "budget": "budget",
+        "policy": "policy",
+        "proposal": "proposal",
+        "deliberation": "deliberation"
+      }
+    },
+    "transcript_format": {
+      "name": "transcript_format",
+      "values": {
+        "json": "json",
+        "txt": "txt",
+        "vtt": "vtt",
+        "srt": "srt"
+      }
+    },
+    "transcript_source": {
+      "name": "transcript_source",
+      "values": {
+        "upload": "upload",
+        "stream": "stream",
+        "import": "import"
+      }
+    },
+    "used_for": {
+      "name": "used_for",
+      "values": {
+        "draft": "draft",
+        "regenerate": "regenerate",
+        "field-specific": "field-specific"
+      }
+    }
+  },
+  "schemas": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -85,6 +85,13 @@
       "when": 1773611400000,
       "tag": "0011_template_category_deliberation",
       "breakpoints": true
+    },
+    {
+      "idx": 12,
+      "version": "5",
+      "when": 1773689936822,
+      "tag": "0012_sweet_romulus",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/scripts/seed.ts
+++ b/packages/db/scripts/seed.ts
@@ -13,6 +13,7 @@
 import { db, client } from "../src/client.js";
 import { CORE_FIELDS } from "../src/seed-data/decision-fields.js";
 import {
+  DELIBERATION_ADR_EXPORT_TEMPLATE,
   prepareDefaultExportTemplatesForSeeding,
   prepareTemplatesForSeeding,
 } from "../src/seed-data/decision-templates.js";
@@ -208,6 +209,57 @@ async function seed() {
     }
 
     console.log(`  ✓ Ensured field assignments for ${exportTemplateSeed.name}`);
+  }
+
+  // Seed ADR export template for Deliberation Decision
+  console.log("\nSeeding ADR export template...");
+  const deliberationTemplateId = templateIdByIdentity.get("core:Deliberation Decision:1");
+  if (deliberationTemplateId) {
+    const adrSeed = {
+      ...DELIBERATION_ADR_EXPORT_TEMPLATE,
+      deliberationTemplateId,
+    };
+    const { fields: adrFields, ...adrRecord } = adrSeed;
+
+    const insertedAdr = await db
+      .insert(exportTemplates)
+      .values({ ...adrRecord, version: 1 })
+      .onConflictDoUpdate({
+        target: [exportTemplates.namespace, exportTemplates.name, exportTemplates.version],
+        set: {
+          deliberationTemplateId,
+          description: adrRecord.description,
+          preamble: adrRecord.preamble,
+        },
+      })
+      .returning();
+
+    const adrRow = insertedAdr[0];
+    if (adrRow) {
+      for (const assignment of adrFields) {
+        const existing = await db
+          .select()
+          .from(exportTemplateFieldAssignments)
+          .where(
+            and(
+              eq(exportTemplateFieldAssignments.exportTemplateId, adrRow.id),
+              eq(exportTemplateFieldAssignments.fieldId, assignment.fieldId),
+            ),
+          )
+          .limit(1);
+
+        if (!existing[0]) {
+          await db.insert(exportTemplateFieldAssignments).values({
+            exportTemplateId: adrRow.id,
+            fieldId: assignment.fieldId,
+            order: assignment.order,
+          });
+        }
+      }
+      console.log("  ✓ Upserted ADR export template");
+    }
+  } else {
+    console.warn("  ⚠ Deliberation Decision template not found — skipping ADR export template");
   }
 
   // Seed Expert Templates

--- a/packages/db/src/repositories/decision-template-repository.ts
+++ b/packages/db/src/repositories/decision-template-repository.ts
@@ -141,6 +141,7 @@ function toExportTemplateInsert(data: CreateExportTemplate): typeof exportTempla
     namespace: data.namespace,
     name: data.name,
     description: data.description,
+    ...(data.preamble !== undefined ? { preamble: data.preamble } : {}),
     ...(lineage !== undefined ? { lineage } : {}),
     ...(provenance !== undefined ? { provenance } : {}),
   };
@@ -583,6 +584,7 @@ export class DrizzleExportTemplateRepository implements IExportTemplateRepositor
       namespace: row.namespace,
       name: row.name,
       description: row.description,
+      ...(row.preamble !== null && row.preamble !== undefined ? { preamble: row.preamble } : {}),
       fields: row.fields || [],
       version: row.version,
       isDefault: row.isDefault,

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -353,6 +353,7 @@ export const exportTemplates = pgTable(
     namespace: text("namespace").notNull().default("core"),
     name: text("name").notNull(),
     description: text("description").notNull(),
+    preamble: text("preamble"),
     version: integer("version").notNull().default(1),
     isDefault: boolean("is_default").notNull().default(false),
     isCustom: boolean("is_custom").notNull().default(false),

--- a/packages/db/src/seed-data/decision-templates.ts
+++ b/packages/db/src/seed-data/decision-templates.ts
@@ -212,6 +212,27 @@ export const PROPOSAL_TEMPLATE: CreateDecisionTemplate = {
   ],
 };
 
+export const DELIBERATION_ADR_EXPORT_TEMPLATE: CreateExportTemplate = {
+  deliberationTemplateId: "00000000-0000-0000-0000-000000000000", // resolved at seed time
+  namespace: "core",
+  name: "ADR Export",
+  description:
+    "Exports a Deliberation Decision as an Architectural Decision Record markdown file with YAML frontmatter.",
+  preamble: "---\ndecision-id: {{decision-id}}\ndate: {{date}}\nslug: {{slug}}\nstatus: {{status}}\n---",
+  fields: [
+    assignment(CORE_FIELD_IDS.CONTEXT, 0),
+    assignment(CORE_FIELD_IDS.TENSION, 1),
+    assignment(CORE_FIELD_IDS.DECISION_QUESTION, 2),
+    assignment(CORE_FIELD_IDS.OPTIONS, 3),
+    assignment(CORE_FIELD_IDS.CRITERIA, 4, false),
+    assignment(CORE_FIELD_IDS.ANALYSIS, 5, false),
+    assignment(CORE_FIELD_IDS.DECISION_STATEMENT, 6),
+    assignment(CORE_FIELD_IDS.OUTCOME, 7),
+    assignment(CORE_FIELD_IDS.CONDITIONS_OF_ENOUGH, 8, false),
+    assignment(CORE_FIELD_IDS.OUTSTANDING_ISSUES, 9, false),
+  ],
+};
+
 // Export all templates
 export const CORE_TEMPLATES: CreateDecisionTemplate[] = [
   DELIBERATION_TEMPLATE,

--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -1059,6 +1059,7 @@ export const ExportTemplateSchema = z
     name: z.string(),
     description: z.string(),
     fields: z.array(ExportTemplateFieldAssignmentSchema),
+    preamble: z.string().optional(),
     version: z.number().int().default(1),
     isDefault: z.boolean().default(false),
     isCustom: z.boolean().default(false),


### PR DESCRIPTION
## Summary

- Adds `preamble` field to `ExportTemplate` — rendered before the `# Decision:` heading with `{{variable}}` substitution (`decision-id`, `date`, `slug`, `status`, `title`)
- Seeds the Deliberation Decision export template with YAML frontmatter for ADR output
- Fixes `ExportTemplate` repository: `preamble` was silently dropped on both read and write paths
- Adds `docs/adr/` directory with the anchor ADR (`2026-03-16-adopt-adr-process.md`) — the first decision logged using the tool itself, establishing the ADR process for the project

## Test plan

- [ ] Export a decision using the Deliberation Decision template — confirm YAML frontmatter appears before the heading
- [ ] Verify `decision-id`, `date`, `slug`, and `status` are substituted correctly
- [ ] Confirm `docs/adr/2026-03-16-adopt-adr-process.md` renders correctly in GitHub
- [ ] Run `pnpm test --filter @repo/db` — all passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)