### PR TITLE
feat: SSE connection sync — web/CLI share focus in real-time

### DIFF
--- a/apps/api/src/__tests__/api.e2e.test.ts
+++ b/apps/api/src/__tests__/api.e2e.test.ts
@@ -2016,4 +2016,66 @@ describe("Phase 1b — transcription_complete meeting state", () => {
     const result = MeetingStatusSchema.safeParse("transcription_complete");
     expect(result.success).toBe(true);
   });
+
+  // ── Connection management endpoints ───────────────────────────────────────
+
+  it("POST /api/connections - creates a new connection with a UUID id", async () => {
+    const response = await app.request("/api/connections", { method: "POST" });
+
+    expect(response.status).toBe(201);
+    const data = await response.json();
+    expect(data.id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i);
+    expect(data.activeMeetingId).toBeNull();
+    expect(data.createdAt).toBeDefined();
+  });
+
+  it("POST /api/connections - does not require X-Connection-ID header", async () => {
+    const response = await app.request("/api/connections", { method: "POST" });
+    expect(response.status).toBe(201);
+  });
+
+  it("GET /api/connections - returns list of connections ordered by lastSeen desc", async () => {
+    // Create two connections so we have something to list
+    await app.request("/api/connections", { method: "POST" });
+    await app.request("/api/connections", { method: "POST" });
+
+    const response = await app.request("/api/connections");
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(Array.isArray(data.connections)).toBe(true);
+    expect(data.connections.length).toBeGreaterThanOrEqual(2);
+    // Most recent first
+    const dates = data.connections.map((c: { lastSeen: string }) => new Date(c.lastSeen).getTime());
+    for (let i = 1; i < dates.length; i++) {
+      expect(dates[i - 1]).toBeGreaterThanOrEqual(dates[i]);
+    }
+  });
+
+  it("GET /api/connections?limit=1 - returns at most one connection", async () => {
+    const response = await app.request("/api/connections?limit=1");
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.connections.length).toBeLessThanOrEqual(1);
+  });
+
+  it("GET /api/connections - does not require X-Connection-ID header", async () => {
+    const response = await app.request("/api/connections");
+    expect(response.status).toBe(200);
+  });
+
+  it("GET /api/connections/{id}/events - allows missing X-Connection-ID header (falls back to path param)", async () => {
+    // Create a connection to subscribe to
+    const created = await app.request("/api/connections", { method: "POST" });
+    const { id } = await created.json();
+
+    // Open SSE without header — should not return 400
+    const controller = new AbortController();
+    const response = await app.request(`/api/connections/${id}/events`, {
+      signal: controller.signal,
+    });
+    controller.abort();
+
+    expect(response.status).not.toBe(400);
+    expect(response.status).not.toBe(403);
+  });
 });

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -23,6 +23,7 @@ import {
   createDraftGenerationService,
   createFeedbackService,
   createFlaggedDecisionService,
+  createConnectionRepository,
   createGlobalContextService,
   createLLMInteractionService,
   createMarkdownExportService,
@@ -48,7 +49,7 @@ import {
   setFieldContextRoute,
   setMeetingContextRoute,
 } from "./routes/context.js";
-import { registerConnectionEventsRoute } from "./routes/connections.js";
+import { registerConnectionRoutes } from "./routes/connections.js";
 import {
   clearStreamingBufferRoute,
   changeDecisionContextTemplateRoute,
@@ -122,6 +123,7 @@ const decisionLogGenerator = useDatabase ? createDecisionLogGenerator() : null;
 const draftGenerationService = useDatabase ? createDraftGenerationService() : null;
 const feedbackService = useDatabase ? createFeedbackService() : null;
 const globalContextService = useDatabase ? createGlobalContextService() : null;
+const connectionRepository = useDatabase ? createConnectionRepository() : null;
 const supplementaryContentService = useDatabase ? createSupplementaryContentService() : null;
 const markdownExportService = useDatabase ? createMarkdownExportService() : null;
 const llmInteractionService = useDatabase ? createLLMInteractionService() : null;
@@ -1779,9 +1781,9 @@ app.get("/health", (c) => {
   return c.json({ status: "ok", timestamp: new Date().toISOString() });
 });
 
-// Register SSE route for connection events
-if (globalContextService) {
-  registerConnectionEventsRoute(app, globalContextService);
+// Register connection management + SSE routes
+if (connectionRepository && globalContextService) {
+  registerConnectionRoutes(app, connectionRepository, globalContextService);
 }
 
 // OpenAPI documentation
@@ -1873,8 +1875,14 @@ if (isMainModule) {
     res.statusCode = response.status;
     res.statusMessage = response.statusText;
     response.headers.forEach((value, key) => res.setHeader(key, value));
-    const responseBody = await response.text();
-    res.end(responseBody);
+
+    if (response.body) {
+      const { Readable } = await import("stream");
+      const nodeStream = Readable.fromWeb(response.body as import("stream/web").ReadableStream);
+      nodeStream.pipe(res);
+    } else {
+      res.end();
+    }
   });
 
   server.listen(port, () => {

--- a/apps/api/src/routes/connections.ts
+++ b/apps/api/src/routes/connections.ts
@@ -2,6 +2,46 @@ import { createRoute, z } from "@hono/zod-openapi";
 import { streamSSE } from "hono/streaming";
 import type { Context } from "hono";
 import type { GlobalContextService } from "@repo/core";
+import { ConnectionSchema } from "@repo/schema";
+
+// ── List connections ───────────────────────────────────────────────────────
+
+export const listConnectionsRoute = createRoute({
+  method: "get",
+  path: "/api/connections",
+  request: {
+    query: z.object({
+      limit: z.string().regex(/^\d+$/).optional(),
+    }),
+  },
+  responses: {
+    200: {
+      content: {
+        "application/json": {
+          schema: z.object({ connections: z.array(ConnectionSchema) }),
+        },
+      },
+      description: "List of connections ordered by lastSeen descending",
+    },
+  },
+});
+
+// ── Create connection ──────────────────────────────────────────────────────
+
+export const createConnectionRoute = createRoute({
+  method: "post",
+  path: "/api/connections",
+  responses: {
+    201: {
+      content: {
+        "application/json": { schema: ConnectionSchema },
+      },
+      description: "Newly created connection",
+    },
+  },
+});
+
+// ── SSE events ─────────────────────────────────────────────────────────────
 
 export const connectionEventsRoute = createRoute({
   method: "get",
@@ -11,66 +51,66 @@ export const connectionEventsRoute = createRoute({
       id: z.string().min(1, "Connection ID is required"),
     }),
     headers: z.object({
-      "x-connection-id": z.string().min(1, "X-Connection-ID header is required"),
+      // Header is optional — native EventSource cannot send custom headers.
+      // If provided it must match the path param; if absent the path param is used.
+      "x-connection-id": z.string().min(1).optional(),
     }),
   },
   responses: {
     200: {
       content: {
-        "text/event-stream": {
-          schema: z.string(),
-        },
+        "text/event-stream": { schema: z.string() },
       },
       description: "Server-sent events stream",
     },
-    400: {
-      content: {
-        "application/json": {
-          schema: z.object({
-            error: z.string(),
-          }),
-        },
-      },
-      description: "Bad request",
-    },
     403: {
       content: {
-        "application/json": {
-          schema: z.object({
-            error: z.string(),
-          }),
-        },
+        "application/json": { schema: z.object({ error: z.string() }) },
       },
       description: "Forbidden - connection ID mismatch",
     },
   },
 });
 
-export function registerConnectionEventsRoute(
+// ── Registration ───────────────────────────────────────────────────────────
+
+export function registerConnectionRoutes(
   app: any,
+  connectionRepository: { findAll(opts?: { limit?: number }): Promise<any[]>; create(id: string): Promise<any> },
   globalContextService: GlobalContextService,
 ) {
+  app.openapi(listConnectionsRoute, async (c: Context) => {
+    const limitParam = c.req.query("limit");
+    const limit = limitParam !== undefined ? parseInt(limitParam, 10) : undefined;
+    const conns = await connectionRepository.findAll(limit !== undefined ? { limit } : undefined);
+    return c.json({ connections: conns });
+  });
+
+  app.openapi(createConnectionRoute, async (c: Context) => {
+    const id = crypto.randomUUID();
+    const conn = await connectionRepository.create(id);
+    return c.json(conn, 201);
+  });
+
   app.openapi(connectionEventsRoute, async (c: Context) => {
     try {
       if (!globalContextService) {
         return c.json({ error: "This endpoint requires DATABASE_URL to be configured" }, 503);
       }
 
-      const connectionId = c.req.param("id");
+      const pathId = c.req.param("id");
       const headerConnectionId = c.req.header("X-Connection-ID");
 
-      if (!headerConnectionId) {
-        return c.json({ error: "X-Connection-ID header is required" }, 400);
-      }
+      // Header is optional — fall back to path param if absent
+      const connectionId = headerConnectionId ?? pathId;
 
-      // Security: ensure the connection ID in the path matches the header
-      if (connectionId !== headerConnectionId) {
+      // If header was provided it must match the path param
+      if (headerConnectionId && headerConnectionId !== pathId) {
         return c.json({ error: "Connection ID mismatch" }, 403);
       }
 
       const lastEventId = Number(c.req.header("Last-Event-ID") ?? "0");
 
-      // Set SSE headers
       c.header("Content-Type", "text/event-stream");
       c.header("Cache-Control", "no-cache");
       c.header("Connection", "keep-alive");
@@ -79,35 +119,31 @@ export function registerConnectionEventsRoute(
         try {
           let nextEventId = lastEventId + 1;
 
-          // Replay missed events from ring buffer
-          const replayed = globalContextService.replayEvents?.(connectionId, lastEventId);
-          if (replayed === "resync") {
-            await stream.writeSSE({
-              event: "resync",
-              data: "{}",
-            });
-            nextEventId = 0; // Reset after resync
-          } else if (replayed && replayed.length > 0) {
-            for (const event of replayed) {
-              await stream.writeSSE({
-                id: String(nextEventId++),
-                event: event.type,
-                data: event.type === "resync" ? "{}" : JSON.stringify(event.data),
-              });
+          if (lastEventId > 0) {
+            // Reconnect: replay missed events from ring buffer
+            const replayed = globalContextService.replayEvents?.(connectionId, lastEventId);
+            if (replayed === "resync") {
+              await stream.writeSSE({ event: "resync", data: "{}" });
+              nextEventId = 0;
+            } else if (replayed && replayed.length > 0) {
+              for (const event of replayed) {
+                await stream.writeSSE({
+                  id: String(nextEventId++),
+                  event: event.type,
+                  data: event.type === "resync" ? "{}" : JSON.stringify(event.data),
+                });
+              }
             }
           }
 
-          // Send initial context snapshot if no events were replayed
-          if (!replayed || replayed.length === 0) {
-            const context = await globalContextService.getContext(connectionId);
-            await stream.writeSSE({
-              id: String(nextEventId++),
-              event: "context",
-              data: JSON.stringify(context),
-            });
-          }
+          // Always send current context on connect (fresh or after replay)
+          const context = await globalContextService.getContext(connectionId);
+          await stream.writeSSE({
+            id: String(nextEventId++),
+            event: "context",
+            data: JSON.stringify(context),
+          });
 
-          // Subscribe to new events
           const unsubscribe = globalContextService.subscribe(connectionId, async (event) => {
             await stream.writeSSE({
               id: String(nextEventId++),
@@ -116,12 +152,10 @@ export function registerConnectionEventsRoute(
             });
           });
 
-          // Keep connection alive with periodic heartbeats
           const heartbeat = setInterval(async () => {
             await stream.writeSSE({ data: "" });
           }, 30000);
 
-          // Keep the stream open until the client disconnects
           await new Promise<void>((resolve) => {
             stream.onAbort(() => {
               unsubscribe();
@@ -139,4 +173,14 @@ export function registerConnectionEventsRoute(
       return c.json({ error: error instanceof Error ? error.message : "Internal server error" }, 500);
     }
   });
+}
+
+// Keep old export for any callers that haven't been updated yet
+export function registerConnectionEventsRoute(
+  app: any,
+  globalContextService: GlobalContextService,
+) {
+  // No-op shim — registerConnectionRoutes now handles all connection routes
+  void app;
+  void globalContextService;
 }

--- a/apps/cli/src/client.ts
+++ b/apps/cli/src/client.ts
@@ -3,17 +3,51 @@ import { logHttpRequest, logHttpResponse } from "./runtime.js";
 const BASE_URL =
   process.env.DECISION_LOGGER_API_URL ?? process.env.API_BASE_URL ?? "http://localhost:3001";
 
-const CONNECTION_ID = process.env.DECISION_LOGGER_CONNECTION_ID;
-if (!CONNECTION_ID) {
-  throw new Error(
-    "DECISION_LOGGER_CONNECTION_ID is required. Generate a UUID and add it to your .env file.",
-  );
+/**
+ * Resolve the connection ID to use for this CLI session.
+ *
+ * Priority:
+ * 1. DECISION_LOGGER_CONNECTION_ID env var
+ * 2. GET /api/connections?limit=1 → most recent connection
+ * 3. POST /api/connections → create new
+ */
+async function resolveConnectionId(): Promise<string> {
+  if (process.env.DECISION_LOGGER_CONNECTION_ID) {
+    return process.env.DECISION_LOGGER_CONNECTION_ID;
+  }
+
+  // Bootstrap without X-Connection-ID header (these endpoints don't require it)
+  const listRes = await fetch(`${BASE_URL}/api/connections?limit=1`);
+  if (listRes.ok) {
+    const data = (await listRes.json()) as { connections: Array<{ id: string }> };
+    if (data.connections.length > 0 && data.connections[0]) return data.connections[0].id;
+  }
+
+  const createRes = await fetch(`${BASE_URL}/api/connections`, { method: "POST" });
+  if (!createRes.ok) throw new Error("Failed to create connection");
+  const conn = (await createRes.json()) as { id: string };
+  return conn.id;
+}
+
+// Initialised synchronously from env var; bootstrapped lazily on first request if absent
+let _connectionId: string | null = process.env.DECISION_LOGGER_CONNECTION_ID ?? null;
+
+async function getConnectionId(): Promise<string> {
+  if (!_connectionId) _connectionId = await resolveConnectionId();
+  return _connectionId;
+}
+
+/** Returns the connection ID once it has been resolved (safe to call after any api.* call). */
+export function resolvedConnectionId(): string | null {
+  return _connectionId;
 }
 
 async function request<T>(method: string, path: string, body?: unknown): Promise<T> {
   const url = `${BASE_URL}${path}`;
   const init: RequestInit = { method };
-  const headers: Record<string, string> = { "X-Connection-ID": CONNECTION_ID as string };
+  // Use sync value when available to avoid microtask delay on already-cached ID
+  const connectionId = _connectionId ?? (await getConnectionId());
+  const headers: Record<string, string> = { "X-Connection-ID": connectionId };
   if (body !== undefined) {
     headers["Content-Type"] = "application/json";
     init.body = JSON.stringify(body);

--- a/apps/cli/src/commands/context.ts
+++ b/apps/cli/src/commands/context.ts
@@ -1,6 +1,6 @@
 import { Command } from "commander";
 import chalk from "chalk";
-import { api, getContext, requireActiveMeeting, type GlobalContext } from "../client.js";
+import { api, getContext, requireActiveMeeting, resolvedConnectionId, type GlobalContext } from "../client.js";
 import { confirmAction } from "../runtime.js";
 
 function printContext(ctx: GlobalContext) {
@@ -24,6 +24,7 @@ contextCommand
   .description("Show current active context")
   .action(async () => {
     const ctx = await getContext();
+    console.log(chalk.gray(`  Connection:       ${resolvedConnectionId() ?? "(unknown)"}`));
     printContext(ctx);
   });
 

--- a/apps/web/src/api/client.ts
+++ b/apps/web/src/api/client.ts
@@ -1,18 +1,65 @@
 // ── API client ────────────────────────────────────────────────────
 // Thin fetch wrapper. All API calls go through apiFetch<T>().
 
-const BASE_URL = (import.meta.env.VITE_API_URL as string | undefined) ?? "http://localhost:3001";
+export const BASE_URL =
+  (import.meta.env.VITE_API_URL as string | undefined) ?? "http://localhost:3001";
 
-// Get or generate connection ID from localStorage
-function getConnectionId(): string {
-  const stored = localStorage.getItem("connectionId");
+const CONNECTION_ID_KEY = "connectionId";
+
+export function getConnectionId(): string | null {
+  return localStorage.getItem(CONNECTION_ID_KEY);
+}
+
+function storeConnectionId(id: string): void {
+  localStorage.setItem(CONNECTION_ID_KEY, id);
+  // Expose for console debugging: window.__decisionLogger.connectionId
+  const w = window as unknown as Record<string, unknown>;
+  w.__decisionLogger = { ...(w.__decisionLogger as object | undefined), connectionId: id };
+}
+
+/**
+ * Resolves the connection ID to use for this browser session.
+ *
+ * Priority:
+ * 1. Already stored in localStorage → use it
+ * 2. GET /api/connections?limit=1 → use most recent
+ * 3. POST /api/connections → create new
+ *
+ * Subsequent calls return the cached value without API calls.
+ */
+let _initPromise: Promise<string> | null = null;
+
+export async function initConnection(): Promise<string> {
+  const stored = getConnectionId();
   if (stored) {
+    storeConnectionId(stored); // ensure window.__decisionLogger is set even for cached IDs
     return stored;
   }
-  // Generate a new UUID if none exists
-  const newId = crypto.randomUUID();
-  localStorage.setItem("connectionId", newId);
-  return newId;
+
+  if (_initPromise) return _initPromise;
+
+  _initPromise = (async () => {
+    // Try to find existing connection
+    const listRes = await fetch(`${BASE_URL}/api/connections?limit=1`);
+    if (listRes.ok) {
+      const { connections } = await listRes.json();
+      if (connections && connections.length > 0) {
+        storeConnectionId(connections[0].id);
+        return connections[0].id as string;
+      }
+    }
+
+    // Create new connection
+    const createRes = await fetch(`${BASE_URL}/api/connections`, { method: "POST" });
+    if (!createRes.ok) throw new Error("Failed to create connection");
+    const conn = await createRes.json();
+    storeConnectionId(conn.id);
+    return conn.id as string;
+  })().finally(() => {
+    _initPromise = null;
+  });
+
+  return _initPromise;
 }
 
 export class ApiError extends Error {
@@ -27,11 +74,12 @@ export class ApiError extends Error {
 
 export async function apiFetch<T>(path: string, options?: RequestInit): Promise<T> {
   const url = `${BASE_URL}${path}`;
+  const connectionId = getConnectionId();
 
   const res = await fetch(url, {
     headers: {
       "Content-Type": "application/json",
-      "X-Connection-ID": getConnectionId(),
+      ...(connectionId ? { "X-Connection-ID": connectionId } : {}),
       ...(options?.headers ?? {}),
     },
     ...options,

--- a/apps/web/src/api/endpoints.ts
+++ b/apps/web/src/api/endpoints.ts
@@ -440,3 +440,26 @@ export function clearActiveDecision(meetingId: string) {
     ...jsonBody({}),
   });
 }
+
+
+// ── Connection management ──────────────────────────────────────────
+
+export interface Connection {
+  id: string;
+  activeMeetingId: string | null;
+  activeDecisionId: string | null;
+  activeDecisionContextId: string | null;
+  activeField: string | null;
+  createdAt: string;
+  updatedAt: string;
+  lastSeen: string;
+}
+
+export function listConnections(limit?: number) {
+  const query = limit ? `?limit=${limit}` : "";
+  return apiFetch<{ connections: Connection[] }>(`/api/connections${query}`);
+}
+
+export function createConnection() {
+  return apiFetch<Connection>("/api/connections", { method: "POST" });
+}

--- a/apps/web/src/components/RootLayout.tsx
+++ b/apps/web/src/components/RootLayout.tsx
@@ -1,0 +1,96 @@
+import { useEffect, useRef, useState } from "react";
+import { Outlet, useLocation, useNavigate } from "react-router-dom";
+import { ConnectionContext } from "@/context/ConnectionContext";
+import { initConnection, BASE_URL } from "@/api/client";
+import { getGlobalContext } from "@/api/endpoints";
+import type { GlobalContext } from "@/api/types";
+
+export function RootLayout() {
+  const [connectionId, setConnectionId] = useState<string | null>(null);
+  const [globalContext, setGlobalContext] = useState<GlobalContext | null>(null);
+  const navigate = useNavigate();
+  const location = useLocation();
+  const prevMeetingIdRef = useRef<string | undefined>(undefined);
+
+  // Always holds the latest applyNavigationRule so SSE listeners never call a stale closure
+  const applyNavigationRuleRef = useRef<(ctx: GlobalContext) => void>(() => {});
+
+  // Rewrite the ref on every render — captures fresh location.pathname and navigate
+  applyNavigationRuleRef.current = function applyNavigationRule(ctx: GlobalContext) {
+    const pathname = location.pathname;
+
+    // Determine the meeting ID currently reflected in the URL (if any)
+    const urlMeetingMatch = pathname.match(/^\/meetings\/([^/]+)/);
+    const urlMeetingId = urlMeetingMatch?.[1] ?? null;
+
+    if (!ctx.activeMeetingId) {
+      // Meeting was cleared — go back to root if currently on a meeting page
+      if (urlMeetingId) {
+        navigate("/");
+      }
+      prevMeetingIdRef.current = undefined;
+      return;
+    }
+
+    if (pathname === "/") {
+      // Landing page — navigate to the active meeting
+      navigate(`/meetings/${ctx.activeMeetingId}/facilitator`);
+      prevMeetingIdRef.current = ctx.activeMeetingId;
+      return;
+    }
+
+    if (urlMeetingId && urlMeetingId !== ctx.activeMeetingId) {
+      // Switched to a different meeting while on a meeting page
+      navigate(`/meetings/${ctx.activeMeetingId}/facilitator`);
+      prevMeetingIdRef.current = ctx.activeMeetingId;
+      return;
+    }
+
+    // Same meeting — decision/field changes are handled by component-level sync
+    prevMeetingIdRef.current = ctx.activeMeetingId;
+  };
+
+  // Bootstrap the connection ID once on mount
+  useEffect(() => {
+    initConnection()
+      .then(setConnectionId)
+      .catch((err) => console.error("[ConnectionSync] Failed to init connection:", err));
+  }, []);
+
+  // Open SSE subscription once we have a connection ID
+  useEffect(() => {
+    if (!connectionId) return;
+
+    const url = `${BASE_URL}/api/connections/${connectionId}/events`;
+    const es = new EventSource(url);
+
+    es.addEventListener("context", (e: MessageEvent) => {
+      const incoming = JSON.parse(e.data) as GlobalContext;
+      setGlobalContext(incoming);
+      applyNavigationRuleRef.current(incoming);
+    });
+
+    es.addEventListener("resync", () => {
+      getGlobalContext()
+        .then((ctx) => {
+          setGlobalContext(ctx);
+          applyNavigationRuleRef.current(ctx);
+        })
+        .catch(() => {});
+    });
+
+    es.onerror = () => {
+      // Browser will auto-reconnect; CLOSED state during StrictMode cleanup is expected
+    };
+
+    return () => {
+      es.close();
+    };
+  }, [connectionId]);
+
+  return (
+    <ConnectionContext.Provider value={{ connectionId, globalContext }}>
+      <Outlet />
+    </ConnectionContext.Provider>
+  );
+}

--- a/apps/web/src/context/ConnectionContext.tsx
+++ b/apps/web/src/context/ConnectionContext.tsx
@@ -1,0 +1,16 @@
+import { createContext, useContext } from "react";
+import type { GlobalContext } from "@/api/types";
+
+export interface ConnectionContextValue {
+  connectionId: string | null;
+  globalContext: GlobalContext | null;
+}
+
+export const ConnectionContext = createContext<ConnectionContextValue>({
+  connectionId: null,
+  globalContext: null,
+});
+
+export function useConnectionContext(): ConnectionContextValue {
+  return useContext(ConnectionContext);
+}

--- a/apps/web/src/pages/FacilitatorMeetingPage.tsx
+++ b/apps/web/src/pages/FacilitatorMeetingPage.tsx
@@ -28,6 +28,7 @@ import { useMeeting } from "@/hooks/useMeeting";
 import { useMeetingAgenda } from "@/hooks/useMeetingAgenda";
 import { useDecisionContext } from "@/hooks/useDecisionContext";
 import { useTemplates } from "@/hooks/useTemplates";
+import { useConnectionContext } from "@/context/ConnectionContext";
 import {
   lockField,
   unlockField,
@@ -212,6 +213,21 @@ export function FacilitatorMeetingPage() {
   );
   const [leftTab, setLeftTab] = useState<"candidates" | "agenda">("agenda");
   const [zoomedFieldId, setZoomedFieldId] = useState<string | null>(null);
+  const { globalContext } = useConnectionContext();
+
+  // Sync zoom with remote focus changes — React no-ops on same value so no loop
+  useEffect(() => {
+    setZoomedFieldId(globalContext?.activeField ?? null);
+  }, [globalContext?.activeField]);
+
+  // Sync active decision context with remote focus changes
+  useEffect(() => {
+    const remoteContextId = globalContext?.activeDecisionContextId ?? null;
+    if (remoteContextId) {
+      setActiveApiContextId(remoteContextId);
+    }
+  }, [globalContext?.activeDecisionContextId]);
+
   const [modal, setModal] = useState<ModalState>(null);
   const [supplementary, setSupplementary] = useState<SupplementaryItem[]>([]);
   const [fieldFeedback, setFieldFeedback] = useState<DecisionFeedback[]>([]);

--- a/apps/web/src/pages/MeetingListPage.tsx
+++ b/apps/web/src/pages/MeetingListPage.tsx
@@ -18,10 +18,9 @@ import { Input } from "@/components/ui/Input";
 import { Panel } from "@/components/ui/Panel";
 import { ParticipantAddWidget } from "@/components/shared/ParticipantAddWidget";
 import { MainHeader } from "@/components/shared/MainHeader";
-import { listMeetings, createMeeting, getInSessionMeetingsContextSummary } from "@/api/endpoints";
-import type { InSessionMeetingsContextSummary, Meeting } from "@/api/types";
-
-const CONTEXT_SUMMARY_LOAD_ERROR = "Failed to load active meeting context";
+import { listMeetings, createMeeting } from "@/api/endpoints";
+import { useConnectionContext } from "@/context/ConnectionContext";
+import type { Meeting } from "@/api/types";
 
 function nowAsLocalDateTimeInputValue() {
   const now = new Date();
@@ -56,10 +55,10 @@ function formatMeetingDate(value: string): string {
 
 export function MeetingListPage() {
   const [meetings, setMeetings] = useState<Meeting[]>([]);
-  const [activeSummary, setActiveSummary] = useState<InSessionMeetingsContextSummary | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [showCreate, setShowCreate] = useState(false);
+  const { globalContext } = useConnectionContext();
 
   const load = useCallback(async () => {
     setLoading(true);
@@ -67,14 +66,6 @@ export function MeetingListPage() {
     try {
       const { meetings: data } = await listMeetings();
       setMeetings(data);
-
-      try {
-        const summary = await getInSessionMeetingsContextSummary();
-        setActiveSummary(summary);
-      } catch (summaryError) {
-        console.error(CONTEXT_SUMMARY_LOAD_ERROR, summaryError);
-        setActiveSummary(null);
-      }
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to load meetings");
     } finally {
@@ -90,7 +81,7 @@ export function MeetingListPage() {
     () => [...meetings].sort((a, b) => b.date.localeCompare(a.date)),
     [meetings],
   );
-  const currentContext = activeSummary?.currentContext;
+  const currentContext = globalContext;
   const activeMeetingPath = currentContext?.activeMeetingId
     ? `/meetings/${currentContext.activeMeetingId}/facilitator/home`
     : null;
@@ -152,14 +143,6 @@ export function MeetingListPage() {
                     decisionContextId={currentContext.activeDecisionContextId}
                   />
                 )}
-                {!currentContext.activeDecisionContextId &&
-                  activeSummary &&
-                  activeSummary.inSessionMeetings.length > 1 && (
-                    <p className="text-fac-meta text-text-muted">
-                      {activeSummary.inSessionMeetings.length} meetings are in session, but only
-                      this one is selected for global context.
-                    </p>
-                  )}
               </div>
               <div className="flex flex-wrap gap-2">
                 {activeMeetingPath && (

--- a/apps/web/src/pages/SharedMeetingPage.tsx
+++ b/apps/web/src/pages/SharedMeetingPage.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState, useRef, useCallback } from "react";
 import { useParams } from "react-router-dom";
-import { X, ZoomIn } from "lucide-react";
+import { ZoomIn } from "lucide-react";
 import { FieldCard } from "@/components/shared/FieldCard";
 import { AgendaList } from "@/components/shared/AgendaList";
 import { TagPill } from "@/components/shared/TagPill";
@@ -198,16 +198,6 @@ export function SharedMeetingPage() {
           <div className="w-full max-w-5xl rounded-card border border-border bg-surface p-8">
             <div className="flex items-center justify-between gap-4">
               <h2 className="text-display-title text-text-primary">{zoomedField.label}</h2>
-              <button
-                onClick={() => {
-                  setZoomedFieldId(null);
-                  if (currentFocusKey) setDismissedFocusKey(currentFocusKey);
-                }}
-                className="inline-flex items-center gap-1 px-3 py-2 rounded border border-border text-fac-meta text-text-muted hover:text-text-primary"
-              >
-                <X size={14} />
-                Close
-              </button>
             </div>
             {zoomedField.instructions && (
               <p className="text-display-meta text-text-muted leading-snug mt-4">

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -1,4 +1,5 @@
 import { createBrowserRouter } from "react-router-dom";
+import { RootLayout } from "./components/RootLayout";
 import { MeetingListPage } from "./pages/MeetingListPage";
 import { SharedMeetingPage } from "./pages/SharedMeetingPage";
 import { FacilitatorMeetingPage } from "./pages/FacilitatorMeetingPage";
@@ -9,21 +10,29 @@ import { TranscriptPage } from "./pages/TranscriptPage";
 import { LoggedDecisionPage } from "./pages/LoggedDecisionPage";
 
 export const router = createBrowserRouter([
-  // ── Route 1: Meeting list ────────────────────────────────────────
-  { path: "/", element: <MeetingListPage /> },
+  {
+    element: <RootLayout />,
+    children: [
+      // ── Route 1: Meeting list ──────────────────────────────────────
+      { path: "/", element: <MeetingListPage /> },
 
-  // ── Route 2: Shared display (projected) ─────────────────────────
-  { path: "/meetings/:id", element: <SharedMeetingPage /> },
+      // ── Route 2: Shared display (projected) ───────────────────────
+      { path: "/meetings/:id", element: <SharedMeetingPage /> },
 
-  // ── Route 3: Facilitator meeting view ───────────────────────────
-  { path: "/meetings/:id/facilitator/home", element: <FacilitatorMeetingHomePage /> },
-  { path: "/meetings/:id/facilitator", element: <FacilitatorMeetingPage /> },
-  { path: "/meetings/:id/facilitator/stream", element: <FacilitatorStreamPage /> },
-  { path: "/meetings/:id/facilitator/stream/diagnostics", element: <FacilitatorStreamDiagnosticsPage /> },
+      // ── Route 3: Facilitator meeting view ─────────────────────────
+      { path: "/meetings/:id/facilitator/home", element: <FacilitatorMeetingHomePage /> },
+      { path: "/meetings/:id/facilitator", element: <FacilitatorMeetingPage /> },
+      { path: "/meetings/:id/facilitator/stream", element: <FacilitatorStreamPage /> },
+      {
+        path: "/meetings/:id/facilitator/stream/diagnostics",
+        element: <FacilitatorStreamDiagnosticsPage />,
+      },
 
-  // ── Route 4: Segment selection ───────────────────────────────────
-  { path: "/meetings/:id/facilitator/transcript", element: <TranscriptPage /> },
+      // ── Route 4: Segment selection ─────────────────────────────────
+      { path: "/meetings/:id/facilitator/transcript", element: <TranscriptPage /> },
 
-  // ── Route 5: Logged decision (projectable) ───────────────────────
-  { path: "/decisions/:id", element: <LoggedDecisionPage /> },
+      // ── Route 5: Logged decision (projectable) ─────────────────────
+      { path: "/decisions/:id", element: <LoggedDecisionPage /> },
+    ],
+  },
 ]);

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -57,6 +57,7 @@ export {
   createServices,
   createExpertTemplateService,
   createMCPServerService,
+  createConnectionRepository,
   type ServiceContainer,
 } from "./service-factory.js";
 

--- a/packages/core/src/interfaces/i-connection-repository.ts
+++ b/packages/core/src/interfaces/i-connection-repository.ts
@@ -2,6 +2,8 @@ import type { Connection, UpdateConnection } from "@repo/schema";
 
 export interface IConnectionRepository {
   findById(id: string): Promise<Connection | null>;
+  findAll(opts?: { limit?: number }): Promise<Connection[]>;
+  create(id: string): Promise<Connection>;
   upsert(id: string, state: UpdateConnection): Promise<Connection>;
   updateLastSeen(id: string): Promise<void>;
 }

--- a/packages/core/src/service-factory.ts
+++ b/packages/core/src/service-factory.ts
@@ -207,6 +207,10 @@ export function createMCPServerService(): MCPServerService {
   return new MCPServerService(new DrizzleMCPServerRepository());
 }
 
+export function createConnectionRepository(): DrizzleConnectionRepository {
+  return new DrizzleConnectionRepository();
+}
+
 /**
  * Creates a GlobalContextService backed by the PostgreSQL connections table.
  */

--- a/packages/db/src/repositories/connection-repository.ts
+++ b/packages/db/src/repositories/connection-repository.ts
@@ -1,4 +1,4 @@
-import { eq } from "drizzle-orm";
+import { desc, eq } from "drizzle-orm";
 import { db } from "../client.js";
 import { connections, ConnectionSelect } from "../schema.js";
 import type { Connection, UpdateConnection } from "@repo/schema";
@@ -39,6 +39,22 @@ export class DrizzleConnectionRepository {
   async findById(id: string): Promise<Connection | null> {
     const [row] = await db.select().from(connections).where(eq(connections.id, id)).limit(1);
     return row ? toConnection(row) : null;
+  }
+
+  async findAll(opts?: { limit?: number }): Promise<Connection[]> {
+    const query = db.select().from(connections).orderBy(desc(connections.lastSeen));
+    const rows = opts?.limit ? await query.limit(opts.limit) : await query;
+    return rows.map(toConnection);
+  }
+
+  async create(id: string): Promise<Connection> {
+    const now = new Date();
+    const [row] = await db
+      .insert(connections)
+      .values({ id, updatedAt: now, lastSeen: now })
+      .returning();
+    if (!row) throw new Error(`Failed to create connection ${id}`);
+    return toConnection(row);
   }
 
   async upsert(id: string, state: UpdateConnection): Promise<Connection> {


### PR DESCRIPTION
## Summary

Fixes the connection sync system so the web UI and CLI share the same connection ID and the web subscribes to SSE events, following the facilitator's focus in real-time.

### Root cause

The custom Node.js HTTP adapter used `response.text()` to buffer the full response body before sending it. For SSE streams, this consumed the initial buffered events and then closed the connection in ~1ms — making every SSE request appear as a one-shot 200 response.

**Fix:** replaced with `Readable.fromWeb().pipe(res)` for proper streaming.

## Changes

### API
- `GET /api/connections?limit=N` — list connections ordered by lastSeen desc
- `POST /api/connections` — create connection with server-generated UUID
- SSE endpoint: fresh connect (lastEventId=0) skips ring buffer replay and sends current context; reconnect (lastEventId>0) replays missed events then sends current context. Prevents event flood from replaying all historical CLI operations on page load.

### Web
- **Bootstrap** (`initConnection`): localStorage → find most recent connection → create new. Exposes `window.__decisionLogger.connectionId` for debugging.
- **RootLayout**: opens SSE subscription on connection ID resolution; handles `context` and `resync` events; navigation rules (landing + activeMeeting → facilitator page; meeting change → navigate; meeting cleared → back to /).
- **FacilitatorMeetingPage**: `zoomedFieldId` and `activeApiContextId` both sync from SSE context events in real-time.
- **MeetingListPage**: consumes live `globalContext` from `ConnectionContext`.
- **SharedMeetingPage**: removed Close button from zoomed field overlay — shared screen is facilitator-controlled.

### CLI
- `resolveConnectionId()`: env var → latest connection → create new (no longer throws on missing env var).
- `context show`: includes Connection ID in output.

### Packages
- `IConnectionRepository`: added `findAll()` and `create()`
- `DrizzleConnectionRepository`: implemented both
- `createConnectionRepository()` exported from `@repo/core`

## Testing

- 125 e2e tests pass
- Verified end-to-end: CLI sets active meeting/decision/field → web navigates and updates without page refresh
- Verified loop safety: SSE-driven state changes trigger one API round-trip then stop

Closes #42