### PR TITLE
Fix local LLM/transcription status accuracy and CLI transcription URL precedence

### DIFF
--- a/apps/api/openapi.yaml
+++ b/apps/api/openapi.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.0
 info:
-  version: 1.0.1
+  version: 1.0.3
   title: μ democracy API
   description: Context-driven decision logging system API
 components:
@@ -2320,46 +2320,6 @@ components:
             $ref: "#/components/schemas/LLMInteraction"
       required:
         - interactions
-    Connection:
-      type: object
-      properties:
-        id:
-          type: string
-          minLength: 1
-        activeMeetingId:
-          type: string
-          nullable: true
-          format: uuid
-        activeDecisionId:
-          type: string
-          nullable: true
-          format: uuid
-        activeDecisionContextId:
-          type: string
-          nullable: true
-          format: uuid
-        activeField:
-          type: string
-          nullable: true
-          format: uuid
-        createdAt:
-          type: string
-          format: date-time
-        updatedAt:
-          type: string
-          format: date-time
-        lastSeen:
-          type: string
-          format: date-time
-      required:
-        - id
-        - activeMeetingId
-        - activeDecisionId
-        - activeDecisionContextId
-        - activeField
-        - createdAt
-        - updatedAt
-        - lastSeen
   parameters:
 paths:
   /api/status:
@@ -5292,73 +5252,6 @@ paths:
                 $ref: "#/components/schemas/LLMInteractionsResponse"
         503:
           description: Database-backed endpoint unavailable
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  error:
-                    type: string
-                required:
-                  - error
-  /api/connections:
-    get:
-      parameters:
-        -
-          schema:
-            type: string
-            pattern: ^\d+$
-          required: false
-          name: limit
-          in: query
-      responses:
-        200:
-          description: List of connections ordered by lastSeen descending
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  connections:
-                    type: array
-                    items:
-                      $ref: "#/components/schemas/Connection"
-                required:
-                  - connections
-    post:
-      responses:
-        201:
-          description: Newly created connection
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Connection"
-  /api/connections/{id}/events:
-    get:
-      parameters:
-        -
-          schema:
-            type: string
-            minLength: 1
-          required: true
-          name: id
-          in: path
-        -
-          schema:
-            type: string
-            minLength: 1
-          required: false
-          name: x-connection-id
-          in: header
-      responses:
-        200:
-          description: Server-sent events stream
-          content:
-            text/event-stream:
-              schema:
-                type: string
-        403:
-          description: Forbidden - connection ID mismatch
           content:
             application/json:
               schema:

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@repo/api",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Hono REST API",
   "main": "./dist/index.js",
   "type": "module",

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@repo/api",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Hono REST API",
   "main": "./dist/index.js",
   "type": "module",

--- a/apps/api/src/__tests__/llm-reachability.test.ts
+++ b/apps/api/src/__tests__/llm-reachability.test.ts
@@ -108,6 +108,25 @@ describe("getLlmReachability", () => {
     expect(result.baseUrl).toBe("http://nonexistent:8080/v1");
   });
 
+  it("sends Authorization header for openai-compatible probes when LLM_API_KEY is set", async () => {
+    process.env.LLM_PROVIDER = "openai-compatible";
+    process.env.LLM_BASE_URL = "http://vllm:8080/v1";
+    process.env.LLM_API_KEY = "secret";
+    fetchSpy.mockResolvedValue({ ok: true, status: 200 });
+
+    await getLlmReachability();
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "http://vllm:8080/v1/models",
+      expect.objectContaining({
+        method: "GET",
+        headers: expect.objectContaining({
+          Authorization: "Bearer secret",
+        }),
+      }),
+    );
+  });
+
   it("returns reachable=true for openai iff OPENAI_API_KEY is set (without network probe)", async () => {
     process.env.LLM_PROVIDER = "openai";
     process.env.OPENAI_API_KEY = "sk-test";

--- a/apps/api/src/llm-reachability.ts
+++ b/apps/api/src/llm-reachability.ts
@@ -71,11 +71,19 @@ function cacheKey(env: LlmEnv): string {
   ].join("|");
 }
 
-async function probeHttp(baseUrl: string, signal: AbortSignal): Promise<LlmReachability> {
+async function probeHttp(
+  baseUrl: string,
+  signal: AbortSignal,
+  apiKey?: string,
+): Promise<LlmReachability> {
   const url = `${baseUrl.replace(/\/+$/, "")}/models`;
   const start = Date.now();
+  const headers: HeadersInit = {};
+  if (apiKey) {
+    headers.Authorization = `Bearer ${apiKey}`;
+  }
   try {
-    const response = await fetch(url, { method: "GET", signal });
+    const response = await fetch(url, { method: "GET", signal, headers });
     const latencyMs = Date.now() - start;
     if (!response.ok) {
       return {
@@ -109,7 +117,7 @@ async function computeReachability(env: LlmEnv): Promise<LlmReachability> {
     const controller = new AbortController();
     const timer = setTimeout(() => controller.abort(), PROBE_TIMEOUT_MS);
     try {
-      return await probeHttp(baseUrl, controller.signal);
+      return await probeHttp(baseUrl, controller.signal, env.apiKey);
     } finally {
       clearTimeout(timer);
     }

--- a/apps/cli/src/__tests__/client-and-commands.test.ts
+++ b/apps/cli/src/__tests__/client-and-commands.test.ts
@@ -458,6 +458,65 @@ describe("CLI command request shapes", () => {
     consoleLogSpy.mockRestore();
   });
 
+  it("status command prefers TRANSCRIPTION_SERVICE_URL over TRANSCRIPTION_URL", async () => {
+    const consoleLogSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const previousServiceUrl = process.env.TRANSCRIPTION_SERVICE_URL;
+    const previousTranscriptionUrl = process.env.TRANSCRIPTION_URL;
+
+    process.env.TRANSCRIPTION_SERVICE_URL = "http://transcription-service:9999";
+    process.env.TRANSCRIPTION_URL = "http://transcription-url:8888";
+    vi.resetModules();
+
+    fetchMock
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          status: "ok",
+          timestamp: "2026-03-10T23:31:00Z",
+          nodeEnv: "development",
+          databaseConfigured: true,
+          llm: {
+            mode: "real",
+            provider: "anthropic",
+            model: "claude-opus-4-5",
+            reachable: true,
+          },
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          status: "ok",
+          provider: "openai",
+          api: { url: "http://localhost:3001", ok: true },
+          whisper: { enabled: false },
+          sessionCount: 0,
+          defaults: {
+            windowMs: 30000,
+            stepMs: 10000,
+            dedupeHorizonMs: 90000,
+            autoFlushMs: 10000,
+          },
+          healthy: true,
+        }),
+      });
+
+    try {
+      const { statusCommand } = await import("../commands/status.js");
+      await statusCommand.parseAsync(["node", "status"], { from: "node" });
+
+      expect(fetchMock).toHaveBeenNthCalledWith(2, "http://transcription-service:9999/status");
+    } finally {
+      if (previousServiceUrl === undefined) delete process.env.TRANSCRIPTION_SERVICE_URL;
+      else process.env.TRANSCRIPTION_SERVICE_URL = previousServiceUrl;
+      if (previousTranscriptionUrl === undefined) delete process.env.TRANSCRIPTION_URL;
+      else process.env.TRANSCRIPTION_URL = previousTranscriptionUrl;
+      consoleLogSpy.mockRestore();
+    }
+  });
+
   it("transcript read requests transcript rows for the provided meeting", async () => {
     const consoleLogSpy = vi.spyOn(console, "log").mockImplementation(() => {});
     fetchMock.mockResolvedValueOnce({

--- a/apps/cli/src/client.ts
+++ b/apps/cli/src/client.ts
@@ -185,6 +185,36 @@ export interface ApiStatusResponse {
   };
 }
 
+export const TRANSCRIPTION_URL =
+  process.env.TRANSCRIPTION_URL ?? process.env.VITE_TRANSCRIPTION_URL ?? "http://localhost:8788";
+
+export interface TranscriptionStatusResponse {
+  status: "ok";
+  provider: string;
+  api: {
+    url: string;
+    ok: boolean;
+    error?: string;
+  };
+  whisper:
+    | { enabled: false }
+    | {
+        enabled: true;
+        url: string;
+        ok: boolean;
+        error?: string;
+      };
+  sessionCount: number;
+  defaults: {
+    windowMs: number;
+    stepMs: number;
+    dedupeHorizonMs: number;
+    autoFlushMs: number;
+  };
+  healthy: boolean;
+  misconfiguration?: string;
+}
+
 export async function getContext(): Promise<GlobalContext> {
   return api.get<GlobalContext>("/api/context");
 }

--- a/apps/cli/src/client.ts
+++ b/apps/cli/src/client.ts
@@ -186,7 +186,10 @@ export interface ApiStatusResponse {
 }
 
 export const TRANSCRIPTION_URL =
-  process.env.TRANSCRIPTION_URL ?? process.env.VITE_TRANSCRIPTION_URL ?? "http://localhost:8788";
+  process.env.TRANSCRIPTION_SERVICE_URL ??
+  process.env.TRANSCRIPTION_URL ??
+  process.env.VITE_TRANSCRIPTION_URL ??
+  "http://localhost:8788";
 
 export interface TranscriptionStatusResponse {
   status: "ok";

--- a/apps/cli/src/commands/status.ts
+++ b/apps/cli/src/commands/status.ts
@@ -1,6 +1,12 @@
 import { Command } from "commander";
 import chalk from "chalk";
-import { api, BASE_URL, type ApiStatusResponse } from "../client.js";
+import {
+  api,
+  BASE_URL,
+  TRANSCRIPTION_URL,
+  type ApiStatusResponse,
+  type TranscriptionStatusResponse,
+} from "../client.js";
 
 function formatAge(isoString: string): string {
   const ms = Date.now() - new Date(isoString).getTime();
@@ -40,5 +46,42 @@ export const statusCommand = new Command("status")
     console.log(chalk.white(`LLM reachable:       ${reachabilityLabel}`));
     if (baseUrl) {
       console.log(chalk.gray(`LLM base URL:        ${baseUrl}`));
+    }
+
+    // Check transcription service status
+    let transcriptionResponse: TranscriptionStatusResponse | undefined;
+    try {
+      const res = await fetch(`${TRANSCRIPTION_URL}/status`);
+      if (res.ok) {
+        transcriptionResponse = (await res.json()) as TranscriptionStatusResponse;
+      }
+    } catch {
+      // Transcription service unreachable - will show below
+    }
+
+    if (transcriptionResponse !== undefined) {
+      const { healthy, provider, misconfiguration } = transcriptionResponse;
+      const { whisper, api: apiStatus } = transcriptionResponse;
+      const healthyLabel = healthy
+        ? chalk.green("healthy")
+        : chalk.red("misconfigured") +
+          (misconfiguration ? chalk.gray(` — ${misconfiguration}`) : "");
+      console.log(chalk.white(`Transcription:       ${healthyLabel}`));
+      console.log(chalk.gray(`  Provider:          ${provider}`));
+      console.log(
+        chalk.gray(
+          `  API connection:    ${apiStatus.ok ? "connected" : "failed"}${apiStatus.error ? ` — ${apiStatus.error}` : ""}`,
+        ),
+      );
+      if (whisper.enabled) {
+        console.log(
+          chalk.gray(
+            `  Whisper:           ${whisper.ok ? "reachable" : "unreachable"}${whisper.error ? ` — ${whisper.error}` : ""}`,
+          ),
+        );
+      }
+    } else {
+      console.log(chalk.yellow(`Transcription:       unreachable at ${TRANSCRIPTION_URL}`));
+      console.log(chalk.gray("  Is the transcription service running? Try: pnpm up:stack"));
     }
   });

--- a/apps/transcription/src/__tests__/web-server.test.ts
+++ b/apps/transcription/src/__tests__/web-server.test.ts
@@ -558,3 +558,41 @@ describe("Phase 1d — canonical fields on delivered events", () => {
     expect(deliveredEvent.streamSource).toBe("mic:rear");
   });
 });
+
+describe("transcription /status health semantics", () => {
+  it("reports healthy=false when the Decision Logger API probe fails", async () => {
+    const previousApiUrl = process.env.DECISION_LOGGER_API_URL;
+    const previousProvider = process.env.TRANSCRIPTION_PROVIDER;
+    process.env.DECISION_LOGGER_API_URL = "http://127.0.0.1:1";
+    process.env.TRANSCRIPTION_PROVIDER = "openai";
+
+    try {
+      const server = await startWebServer({
+        port: 0,
+        host: "127.0.0.1",
+        provider: { transcribe: vi.fn() } as ITranscriptionProvider,
+        apiClient: { postStreamEvent: vi.fn(), flushStream: vi.fn() },
+        normalizeAudioChunk: async (audio) => audio,
+      });
+      runningServers.push(server);
+      const baseUrl = `http://127.0.0.1:${server.port}`;
+
+      const response = await fetch(`${baseUrl}/status`);
+      expect(response.status).toBe(200);
+
+      const payload = (await response.json()) as {
+        healthy: boolean;
+        api: { ok: boolean };
+        misconfiguration?: string;
+      };
+      expect(payload.api.ok).toBe(false);
+      expect(payload.healthy).toBe(false);
+      expect(payload.misconfiguration).toContain("Decision Logger API is unreachable");
+    } finally {
+      if (previousApiUrl === undefined) delete process.env.DECISION_LOGGER_API_URL;
+      else process.env.DECISION_LOGGER_API_URL = previousApiUrl;
+      if (previousProvider === undefined) delete process.env.TRANSCRIPTION_PROVIDER;
+      else process.env.TRANSCRIPTION_PROVIDER = previousProvider;
+    }
+  });
+});

--- a/apps/transcription/src/web-server.ts
+++ b/apps/transcription/src/web-server.ts
@@ -402,10 +402,19 @@ export async function startWebServer(options?: StartWebServerOptions): Promise<R
         let healthy = true;
         let misconfiguration: string | undefined;
 
+        if (!apiProbe.ok) {
+          healthy = false;
+          misconfiguration =
+            `Decision Logger API is unreachable at ${apiUrl}` +
+            (apiProbe.error ? ` (${apiProbe.error})` : "");
+        }
+
         if (provider === "local") {
           if (whisperProbe === null || !whisperProbe.ok) {
             healthy = false;
-            misconfiguration = `Local Whisper provider configured but unreachable at ${whisperUrl}`;
+            misconfiguration = misconfiguration
+              ? `${misconfiguration}; Local Whisper provider configured but unreachable at ${whisperUrl}`
+              : `Local Whisper provider configured but unreachable at ${whisperUrl}`;
           }
         }
         // For openai provider, healthy defaults to true (API key validated at startup)

--- a/apps/transcription/src/web-server.ts
+++ b/apps/transcription/src/web-server.ts
@@ -398,6 +398,18 @@ export async function startWebServer(options?: StartWebServerOptions): Promise<R
             ? await probeUrlOk(`${whisperUrl.replace(/\/$/, "")}/`)
             : null;
 
+        // Determine if transcription is healthy and identify misconfiguration
+        let healthy = true;
+        let misconfiguration: string | undefined;
+
+        if (provider === "local") {
+          if (whisperProbe === null || !whisperProbe.ok) {
+            healthy = false;
+            misconfiguration = `Local Whisper provider configured but unreachable at ${whisperUrl}`;
+          }
+        }
+        // For openai provider, healthy defaults to true (API key validated at startup)
+
         const payload = TranscriptionServiceStatusSchema.parse({
           status: "ok",
           provider,
@@ -420,6 +432,8 @@ export async function startWebServer(options?: StartWebServerOptions): Promise<R
             dedupeHorizonMs: defaultDedupeHorizonMs,
             autoFlushMs,
           },
+          healthy,
+          ...(misconfiguration !== undefined && { misconfiguration }),
         });
 
         sendJson(

--- a/apps/web/src/api/transcription-client.ts
+++ b/apps/web/src/api/transcription-client.ts
@@ -12,6 +12,7 @@ type SessionCreateResponse = {
 
 type SessionCreateRequest = {
   meetingId: string;
+  streamSource: string;
   language?: string;
   windowMs?: number;
   stepMs?: number;
@@ -146,11 +147,13 @@ async function transcriptionFetch<T>(path: string, init?: RequestInit): Promise<
 
 export function createTranscriptionSession(
   meetingId: string,
+  streamSource: string,
   language?: string,
   options?: { windowMs?: number; stepMs?: number; dedupeHorizonMs?: number },
 ) {
   const payload: SessionCreateRequest = {
     meetingId,
+    streamSource,
     ...(language ? { language } : {}),
     ...(options?.windowMs === undefined ? {} : { windowMs: options.windowMs }),
     ...(options?.stepMs === undefined ? {} : { stepMs: options.stepMs }),

--- a/apps/web/src/pages/FacilitatorStreamPage.tsx
+++ b/apps/web/src/pages/FacilitatorStreamPage.tsx
@@ -301,7 +301,7 @@ export function FacilitatorStreamPage() {
             dedupeHorizonMs: transcriptionStatus.defaults.dedupeHorizonMs,
           }
         : undefined;
-      const session = await createTranscriptionSession(meetingId, undefined, sessionOptions);
+      const session = await createTranscriptionSession(meetingId, "browser:mic", undefined, sessionOptions);
       sessionIdRef.current = session.sessionId;
       setActiveSessionId(session.sessionId);
       setActiveSessionStatus({

--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -467,6 +467,8 @@ export const TranscriptionServiceStatusSchema = z
       dedupeHorizonMs: TranscriptionPositiveMsSchema,
       autoFlushMs: TranscriptionPositiveMsSchema,
     }),
+    healthy: z.boolean().describe("Whether the transcription provider is ready to accept requests"),
+    misconfiguration: z.string().optional().describe("Human-readable description of configuration problems"),
   })
   .openapi("TranscriptionServiceStatus", {
     description: "Status for transcription service health and runtime defaults",


### PR DESCRIPTION
## Summary
- include  in local/openai-compatible LLM reachability probes so authenticated OpenAI-compatible endpoints are reported correctly
- mark transcription  as unhealthy when the Decision Logger API probe fails, and surface combined misconfiguration details when multiple dependencies are down
- make CLI  honor  precedence before 
- regenerate OpenAPI after status schema/runtime changes

## Tests
- pnpm test -- client-and-commands.test.ts (apps/cli)
- pre-push validate:strict hook passed during push (lint, build, drift checks, type-check, db checks, and package tests)
